### PR TITLE
Added Capybara and got it working correctly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,11 @@ group :development do
   gem "letter_opener"
 end
 
+
+group :development, :test do
+  gem 'capybara', '~> 2.0.2'
+end
+
 # use postgres database in production mode
 group :production do
   gem 'pg'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,9 +37,18 @@ GEM
     bootswatch-rails (0.3.2)
       railties (>= 3.1)
     builder (3.0.4)
+    capybara (2.0.2)
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      selenium-webdriver (~> 2.0)
+      xpath (~> 1.0.0)
     carrierwave (0.8.0)
       activemodel (>= 3.2.0)
       activesupport (>= 3.2.0)
+    childprocess (0.3.9)
+      ffi (~> 1.0, >= 1.0.11)
     coffee-rails (3.2.2)
       coffee-script (>= 2.2.0)
       railties (~> 3.2.0)
@@ -56,6 +65,8 @@ GEM
     excon (0.13.4)
     execjs (1.4.0)
       multi_json (~> 1.0)
+    ffi (1.6.0)
+    ffi (1.6.0-x86-mingw32)
     fog (1.3.1)
       builder
       excon (~> 0.13.0)
@@ -121,11 +132,17 @@ GEM
     rdoc (3.12.1)
       json (~> 1.4)
     ruby-hmac (0.4.0)
+    rubyzip (0.9.9)
     sass (3.2.5)
     sass-rails (3.2.6)
       railties (~> 3.2.0)
       sass (>= 3.1.10)
       tilt (~> 1.3)
+    selenium-webdriver (2.31.0)
+      childprocess (>= 0.2.5)
+      multi_json (~> 1.0)
+      rubyzip
+      websocket (~> 1.0.4)
     sprockets (2.2.2)
       hike (~> 1.2)
       multi_json (~> 1.0)
@@ -147,6 +164,9 @@ GEM
       multi_json (~> 1.0, >= 1.0.2)
     warden (1.2.1)
       rack (>= 1.0)
+    websocket (1.0.7)
+    xpath (1.0.0)
+      nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
@@ -155,6 +175,7 @@ PLATFORMS
 DEPENDENCIES
   bootstrap-sass (~> 2.3.0)
   bootswatch-rails
+  capybara (~> 2.0.2)
   carrierwave
   coffee-rails (~> 3.2.1)
   devise

--- a/test/integration/user_redirected_to_login_test.rb
+++ b/test/integration/user_redirected_to_login_test.rb
@@ -3,7 +3,14 @@ require 'test_helper'
 class UserRedirectedToLoginTest < ActionDispatch::IntegrationTest
   test "User ends up on login page when they try to log in" do
     # GIVEN: we're on the home page
-    get "/"
+    # get "/"
+
+
+    visit '/'
+    
+    click_link 'Login'
+
+    assert_equal '/profiles/sign_in', page.current_path
 
     # WHEN: we click the login button
     # check login button is there

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,8 @@ ENV["RAILS_ENV"] = "test"
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 
+require 'capybara/rails'
+
 class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.(yml|csv) for all tests in alphabetical order.
   #
@@ -10,4 +12,13 @@ class ActiveSupport::TestCase
   fixtures :all
 
   # Add more helper methods to be used by all tests here...
+end
+
+class ActionDispatch::IntegrationTest
+  include Capybara::DSL
+
+  teardown do
+    Capybara.reset_sessions!
+    Capybara.use_default_driver
+  end
 end


### PR DESCRIPTION
This adds the Capybara gem, and does the basic setup needed to use it in Rails' Integration tests.

I made one of our example integration tests work with it in `test/integration/user_redirected_to_login_test.rb`.

Useful documentation here:

http://rubydoc.info/github/jnicklas/capybara#The_DSL

The thing to remember is that with Capybara you're driving your web app as if you were a person driving it with a browser. So, you need to start off by visiting a page with `visit`, and interacting with by filling in form fields (with `fill_in`) or clicking links or buttons (`click_link`, `click_button`). If you perform an action that would take you to another page, e.g. clicking a link or submitting a form, Capybara will follow the link or submit the form.

The finders for form fields are great, but they rely on you using good form markup.

That just means code like this:

```
<label for="my-form-field">An opinion</label><input type="text" id="my-form-field" name="my_form_field">
```

You could fill in that field with capybara using:

```
fill_in 'An opinion', :with => 'blah blah'
```

Don't forget you'll then need to click the submit button...
