### PR TITLE
added explicit ruby version dependency and gemset to use with rvm

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'https://rubygems.org'
-
+ruby '2.1.2'
+#ruby-gemset=speakerinnen_rails_3
 gem 'rails', '3.2.16'
 gem 'bootstrap-sass', '~> 2.3.0'
 gem 'normalize-rails'


### PR DESCRIPTION
solves https://github.com/rubymonsters/speakerinnen_liste/issues/272 by explicitly setting the ruby version and defining the gemset to use, if you use rvm to manage ruby installations and gemsets
