### PR TITLE
added link to homepage on 404errorpage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@
 /tmp
 
 # Ignore the public directory
-/public
 /config/database.yml
 # /db/structure.sql
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -10,7 +10,7 @@ SpeakerinnenListe::Application.configure do
   config.whiny_nils = true
 
   # Show full error reports and disable caching
-  config.consider_all_requests_local       = true
+  config.consider_all_requests_local       =false
   config.action_controller.perform_caching = false
 
   # Don't care if the mailer can't send

--- a/public/404.html
+++ b/public/404.html
@@ -21,6 +21,7 @@
   <div class="dialog">
     <h1>The page you were looking for doesn't exist.</h1>
     <p>You may have mistyped the address or the page may have moved.</p>
+    <p>GO BACK: <a href="https://speakerinnen.org/">Speakerinnen Liste</a> </p>
   </div>
 </body>
 </html>


### PR DESCRIPTION
This is a pull request for issue #295 ( add home link to error pages (e.g. 404)).
Please note that .gitignore was changed.
Please also note that config file changes were done in order to replicate error in development mode.
