### PR TITLE
changed redirect after confirmation to users profile page

### DIFF
--- a/app/controllers/confirmations_controller.rb
+++ b/app/controllers/confirmations_controller.rb
@@ -1,0 +1,18 @@
+class ConfirmationsController < Devise::ConfirmationsController
+  
+  protected
+
+  # The path used after confirmation.
+  def after_confirmation_path_for(resource_name, resource)
+    path = profile_path(resource.id)
+    if Devise.allow_insecure_sign_in_after_confirmation
+      path
+    elsif signed_in?
+      path
+    else
+      scope = Devise::Mapping.find_scope!(resource)
+      session["#{scope}_return_to"] = path
+      new_session_path(resource_name)
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,10 @@ SpeakerinnenListe::Application.routes.draw do
       root to: 'dashboard#index'
     end
 
-    devise_for :profiles, controllers: {omniauth_callbacks: "omniauth_callbacks"}
+    devise_for :profiles, controllers: {
+      omniauth_callbacks: "omniauth_callbacks",
+      confirmations: :confirmations
+    }
 
     get 'topics/:topic', to: 'profiles#index', as: :topic
 


### PR DESCRIPTION
Changed redirect after confirmation so that speakers who have just registered over the speakerinnen platform will be redirected to their profile after the first login.
