### PR TITLE
enabled api request for many profiles at once because it is more user…

### DIFF
--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -1,0 +1,21 @@
+class Api::V1::ProfilesController < ApplicationController
+  before_filter :api_authentication_required
+  respond_to :json
+
+  def index
+    respond_with Profile.is_published.where(id: params.fetch(:ids)) #we use fetch because it raises an exception instead of returning nil
+  end
+
+  def show
+    respond_with Profile.is_published.find(params.fetch(:id))
+  end
+
+  private
+
+  def api_authentication_required
+    authenticate_or_request_with_http_basic do |name, token|
+      api_token = ApiToken.find_by(name: name)
+      api_token.token.present? && api_token.token == token
+    end
+  end
+end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -6,7 +6,6 @@ class ProfilesController < ApplicationController
   before_action :set_profile, only: [:show, :edit, :update, :destroy, :require_permission]
 
   before_filter :require_permission, only: [:edit, :destroy, :update]
-  before_filter :api_authentication_required, if: ->(controller){ controller.request.format.json? }
 
   def index
     if params[:topic]
@@ -35,11 +34,6 @@ class ProfilesController < ApplicationController
     if @profile.published? or can_edit_profile?(current_profile, @profile)
       @message = Message.new
       @medialinks = @profile.medialinks.order(:position)
-
-      respond_to do |format|
-        format.html
-        format.json { render json: @profile }
-      end
     else
       redirect_to profiles_url, notice: (I18n.t('flash.profiles.show_no_permission'))
     end
@@ -125,20 +119,5 @@ class ProfilesController < ApplicationController
               .order('created_at DESC')
               .page(params[:page])
               .per(24)
-    end
-
-    def api_authentication_required
-      authenticate_or_request_with_http_basic do |name, token|
-        api_token = ApiToken.find_by(name: name)
-        api_token.token.present? && api_token.token == token
-      end
-      #authenticate_or_request_with_http_basic do |name, token|
-        #api_token = ApiToken.find_by(name: name)
-        #if api_token.present?
-          #api_token.token == token
-        #else
-          #render :status => 403
-        #end
-      #end
     end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,12 @@ SpeakerinnenListe::Application.routes.draw do
       root to: 'dashboard#index'
     end
 
+    namespace :api do
+      namespace :v1 do
+        resources :profiles, only: [:index, :show]
+      end
+    end
+
     devise_for :profiles, controllers: {
       omniauth_callbacks: 'omniauth_callbacks',
       confirmations: :confirmations

--- a/spec/controllers/api/v1/profiles_controller_spec.rb
+++ b/spec/controllers/api/v1/profiles_controller_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+include AuthHelper
+
+describe Api::V1::ProfilesController, type: :controller do
+  let!(:profile1) { FactoryGirl.create(:published) }
+
+  describe 'test index action' do
+    let!(:profile2) { FactoryGirl.create(:published, email: 'Maria@example.com') }
+    let!(:unpublished_profile) { FactoryGirl.create(:profile, email: 'Peter@example.com') }
+
+    before do
+      http_login("horst", "123")
+    end
+
+    it 'should return many profiles for json request' do
+      get :index, ids: [profile1.id, profile2.id], format: :json
+
+      expect(response.body).to include('{"id":' + profile1.id.to_s + ',"firstname"')
+      expect(response.body).to include('{"id":' + profile2.id.to_s + ',"firstname"')
+    end
+
+    it 'should filter published profiles by id' do
+      get :index, ids: [profile1.id], format: :json
+
+      expect(response.body).to include('{"id":' + profile1.id.to_s + ',"firstname"')
+      expect(response.body).not_to include('{"id":' + profile2.id.to_s + ',"firstname"')
+    end
+
+    it 'should not show unpublished profiles' do
+      get :index, ids: [unpublished_profile.id], format: :json
+
+      expect(response.body).to eq "[]"
+    end
+  end
+
+  describe 'show action' do
+    it 'should respond to json request for one profile' do
+      http_login("horst", "123")
+      get :show, id: profile1.id, format: "json"
+      expect(response.body).to include('{"id":' + profile1.id.to_s + ',"firstname":"Factory","lastname":"Girl"')
+    end
+
+    it 'should deny json requests without a login' do
+      get :show, id: profile1.id, format: "json"
+      expect(response.status).to eq(401)
+    end
+  end
+end

--- a/spec/controllers/profiles_spec.rb
+++ b/spec/controllers/profiles_spec.rb
@@ -61,17 +61,6 @@ describe ProfilesController, type: :controller do
         get :show, id: profile1.id
         expect(response).to render_template(:show)
       end
-
-      it 'should respond to json request' do
-        http_login("horst", "123")
-        get :show, id: profile1.id, format: "json"
-        expect(response.body).to include('{"id":' + profile1.id.to_s + ',"firstname":"Factory","lastname":"Girl"')
-      end
-
-      it 'should deny json requests without a login' do
-        get :show, id: profile1.id, format: "json"
-        expect(response.status).to eq(401)
-      end
     end
   end
 


### PR DESCRIPTION
…friendly for DMW

created new api controller to have more seperation of concerns
v1 is used for versioning so we can deprecate api more gracefully