### PR TITLE
Changes regex for cities so they are not split on spaces.

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -69,7 +69,7 @@ class Profile < ActiveRecord::Base
   end
 
   def cities
-    "#{city}".gsub(/(,|\/)/, "").split(" ")
+    "#{city}".gsub(/(,|\/|&|\*)/, "***").split("***")
   end
 
   def split_languages


### PR DESCRIPTION
e.g. "San Francisco" stays.