### PR TITLE
Adds a new scope to view the matching profiles in the locale

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,6 +1,6 @@
 class PagesController < ApplicationController
   def home
-    @profiles   = Profile.is_published.random.limit(8)
+    @profiles   = Profile.is_published.main_topic_translated_in(I18n.locale).random.limit(8)
     @categories = Category.sorted_categories
     @blog_posts = BlogPost.order('created_at DESC').limit(2)
   end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -92,6 +92,7 @@ class ProfilesController < ApplicationController
 
   def profiles_for_index
     Profile.is_published
+      .main_topic_translated_in(I18n.locale)
       .random
       .page(params[:page])
       .per(24)

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -64,6 +64,11 @@ class Profile < ActiveRecord::Base
 
   scope :no_admin, -> { where(admin: false) }
 
+  # only show profile where the main_topic is filled in in the current locale
+  scope :main_topic_translated_in, -> (locale) { joins("INNER JOIN profile_translations ON profile_translations.profile_id = profiles.id")
+    .where('profile_translations.locale' => locale)
+    .where.not("profile_translations.main_topic" => [nil, '']) }
+
   def fullname
     "#{firstname} #{lastname}".strip
   end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -67,7 +67,8 @@ class Profile < ActiveRecord::Base
   # only show profile where the main_topic is filled in in the current locale
   scope :main_topic_translated_in, -> (locale) { joins("INNER JOIN profile_translations ON profile_translations.profile_id = profiles.id")
     .where('profile_translations.locale' => locale)
-    .where.not("profile_translations.main_topic" => [nil, '']) }
+    .where.not("profile_translations.main_topic" => [nil, ''])
+  }
 
   def fullname
     "#{firstname} #{lastname}".strip

--- a/spec/controllers/profiles_controller_spec.rb
+++ b/spec/controllers/profiles_controller_spec.rb
@@ -4,6 +4,13 @@ describe ProfilesController, type: :controller do
   describe 'test index action' do
     let!(:profile) { FactoryGirl.create(:published) }
     let!(:profile2) { FactoryGirl.create(:profile) }
+    let!(:ada) { Profile.create!(FactoryGirl.attributes_for(:published,
+                    translations_attributes:
+                      { '0':
+                        { 'locale':       'en',
+                          'main_topic':   'first computer program',
+                          'bio':          'first female programer' }
+                        })) }
 
     before do
       get :index
@@ -16,7 +23,7 @@ describe ProfilesController, type: :controller do
     end
 
     it 'should display published profiles' do
-      expect(assigns(:profiles)).to eq([profile])
+      expect(assigns(:profiles)).to eq([ada])
     end
 
     it 'should not include unpublished profiles' do

--- a/test/integration/user_profile_correctly_displayed_test.rb
+++ b/test/integration/user_profile_correctly_displayed_test.rb
@@ -2,24 +2,26 @@ require 'test_helper'
 
 class UserProfileCorrectlyDisplayedTest < ActionDispatch::IntegrationTest
   def setup
-    @ada              = profiles(:one)
+    @ada              = Profile.where(firstname: "Ada").first
     @ada.confirmed_at = Time.now
     @ada.topic_list   = 'fruehling'
     @ada.bio          = 'Bio von Ada'
     @ada.published    = true
-    @ada.save
+    @ada.attributes   = {main_topic: "Teatime", locale: :en}
+    @ada.save!
 
-    @inge              = profiles(:two)
+    @inge              = Profile.where(firstname: "Inge").first
     @inge.confirmed_at = Time.now
     @inge.topic_list   = 'fruehling', ' ', 'sommer'
     @inge.bio          = 'Bio von Inge'
     @inge.published    = true
-    @inge.save
+    @inge.attributes   = {main_topic: "Sauerkraut", locale: :de}
+    @inge.save!
   end
 
   test 'user profile is correctly displayed' do
     visit '/en'
-    click_link('Ada Lovelace')
+    click_link('Ada Lovelace', :match => :first)
 
     assert page.has_css?('h1'), 'one  of the fullname'
     assert page.has_content?('My topics')
@@ -29,7 +31,7 @@ class UserProfileCorrectlyDisplayedTest < ActionDispatch::IntegrationTest
 
   test 'user profile is correctly displayed in german' do
     visit '/de'
-    click_link('Inge lastname')
+    click_link('Inge lastname', :match => :first)
 
     assert page.has_css?('h1'), 'one headline of the fullname'
     assert page.has_content?('Meine Themen')


### PR DESCRIPTION
https://github.com/rubymonsters/speakerinnen_liste/issues/506

Added a new scope for the home page and the index profiler page, so that when you are randomly viewing profiles, you only get to see the profiles that have the main_topic filled in, in yourI18n locale.

For example when you have the German language selected, you only want to see profiles with a German main_topic in  the overview pages. 

That scope is not implemented in the search, category or tags view. 
