### PR TITLE
Autosuggest returns unique and up cased suggestions.

### DIFF
--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -45,7 +45,7 @@
 
           <%= render partial: 'profiles/profile_search', collection: @profiles, as: :profile %>
 
-        <% elsif @profiles.size <1 && @profiles.response.response.suggest.did_you_mean_fullname.first.options.present? %>
+        <% elsif @profiles.size <1 && @profiles.response.response.suggest.did_you_mean_fullname.first.present? %>
           <p class="text--color-blue font-size-24 text--left layout__item 1/1">
           <%= t(:did_you_mean, scope: 'search', suggestions_fullname: @profiles.response.response.suggest.did_you_mean_fullname.first.options.map {|sug| link_to(sug.text.capitalize, "profiles_search?&search=#{sug.text}")} * ", " ).html_safe %>
           </p>


### PR DESCRIPTION
Uppercases every word and removes doubles.
(Return value for typeahead is an array containing hashes with `text` and `scoring`. This changes the `text` values.)