### PR TITLE
translation of city field

### DIFF
--- a/app/controllers/admin/profiles_controller.rb
+++ b/app/controllers/admin/profiles_controller.rb
@@ -78,7 +78,6 @@ class Admin::ProfilesController < Admin::BaseController
       :password,
       :password_confirmation,
       :remember_me,
-      :city,
       :country,
       {iso_languages: []},
       :firstname,
@@ -100,7 +99,9 @@ class Admin::ProfilesController < Admin::BaseController
       :twitter_en,
       :website_de,
       :website_en,
-      translations_attributes: [:id, :bio, :main_topic, :twitter, :website, :locale])
+      :city_de,
+      :city_en,
+      translations_attributes: [:id, :bio, :main_topic, :twitter, :website, :city, :locale])
   end
 
   def sort_column

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -121,7 +121,6 @@ class ProfilesController < ApplicationController
       :password,
       :password_confirmation,
       :remember_me,
-      :city,
       :country,
       {iso_languages: []},
       :firstname,

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -144,7 +144,9 @@ class ProfilesController < ApplicationController
       :twitter_en,
       :website_de,
       :website_en,
-      translations_attributes: [:id, :bio, :main_topic, :twitter, :website, :locale])
+      :city_de,
+      :city_en,
+      translations_attributes: [:id, :bio, :main_topic, :twitter, :website, :city, :locale])
   end
 
   def custom_params

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -111,7 +111,7 @@ module Searchable
         output = as_json(
           {
             autocomplete: { input:  [fullname, twitter_de, twitter_en, topic_list] },
-            only: [:firstname, :lastname, :iso_languages, :city, :country],
+            only: [:firstname, :lastname, :iso_languages, :country],
               methods: [:fullname, :topic_list, :cities, *globalize_attribute_names],
               include: {
                 medialinks: { only: [:title, :description] }

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -79,7 +79,9 @@ class Profile < ActiveRecord::Base
   end
 
   def cities
-    "#{city}".gsub(/(,|\/|&|\*|\|| - | or )/, "!@#$%ˆ&*").split("!@#$%ˆ&*").map {|x| x.strip}
+    @cities_de = "#{city_de}".gsub(/(,|\/|&|\*|\|| - | or )/, "!@#$%ˆ&*").split("!@#$%ˆ&*").map {|x| x.strip}
+    @cities_en = "#{city_en}".gsub(/(,|\/|&|\*|\|| - | or )/, "!@#$%ˆ&*").split("!@#$%ˆ&*").map {|x| x.strip}
+    (@cities_de << @cities_en).flatten!.uniq
   end
 
   def name_or_email

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -79,9 +79,9 @@ class Profile < ActiveRecord::Base
   end
 
   def cities
-    @cities_de = "#{city_de}".gsub(/(,|\/|&|\*|\|| - | or )/, "!@#$%ˆ&*").split("!@#$%ˆ&*").map {|x| x.strip}
-    @cities_en = "#{city_en}".gsub(/(,|\/|&|\*|\|| - | or )/, "!@#$%ˆ&*").split("!@#$%ˆ&*").map {|x| x.strip}
-    (@cities_de << @cities_en).flatten!.uniq
+    cities_de = "#{city_de}".gsub(/(,|\/|&|\*|\|| - | or )/, "!@#$%ˆ&*").split("!@#$%ˆ&*").map {|x| x.strip}
+    cities_en = "#{city_en}".gsub(/(,|\/|&|\*|\|| - | or )/, "!@#$%ˆ&*").split("!@#$%ˆ&*").map {|x| x.strip}
+    (cities_de << cities_en).flatten!.uniq
   end
 
   def name_or_email

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -10,9 +10,9 @@ class Profile < ActiveRecord::Base
   validate :iso_languages_array_has_right_format
   before_save :clean_iso_languages!
 
-  translates :bio, :main_topic, :twitter, :website, fallbacks_for_empty_translations: true
+  translates :bio, :main_topic, :twitter, :website, :city, fallbacks_for_empty_translations: true
   accepts_nested_attributes_for :translations
-  globalize_accessors :locales => [:en, :de], :attributes => [:main_topic, :bio, :twitter, :website]
+  globalize_accessors :locales => [:en, :de], :attributes => [:main_topic, :bio, :twitter, :website, :city]
 
   extend FriendlyId
   friendly_id :slug_candidate, use: :slugged

--- a/app/views/shared/_profile_formfields.html.erb
+++ b/app/views/shared/_profile_formfields.html.erb
@@ -25,7 +25,6 @@
 
     <%= f.input :firstname, label_html: { id: "firstname" }, input_html: { class: "mb input--width-100" } %>
     <%= f.input :lastname, label_html: { id: "lastname" }, input_html: { class: "mb input--width-100" } %>
-    <%= f.input :city, label: t(:city, scope: 'activerecord.attributes.profile').html_safe, label_html: { id: "city", class: "tooltip", title: t(:city_tooltip, scope: 'activerecord.attributes.profile').html_safe }, input_html: { class: "mb input--width-100" } %>
     <%= f.label :country, input_html: { class: "mb input--width-100" } %>
     <%= f.country_select :country, label: t(:country, scope: 'activerecord.attributes.profile').html_safe, label_html: { id: "country" },
         priority_countries: ["DE", "FR", "GB"], include_blank: t(:country_select, scope: 'profiles.profile'),
@@ -62,6 +61,8 @@
     </ul>
 
     <div id="edit-de" class="ox__bg bg--white pt+ <%= "hidden" unless I18n.locale == :de %>" >
+      <%= f.label :city, t(:city, scope: 'activerecord.attributes.profile').html_safe, id: "city_de", class: "tooltip", title: t(:city_tooltip, scope: 'activerecord.attributes.profile').html_safe %>
+      <%= f.text_field :city_de, as: :text, class: 'mb input--width-100', maxlength: '30' %>
       <%= f.label :twitter, id: "twitter_de", class: "mb input--width-100" %>
       <%= f.text_field :twitter_de, as: :text, placeholder: '@', class: "profile_twitter mb input--width-100", maxlength: 30 %>
       <%= f.label :website, id: "website_de", class: "mb input--width-100" %>
@@ -75,6 +76,8 @@
     </div>
 
     <div id="edit-en" class="box__bg bg--white pt+ <%= "hidden" unless I18n.locale == :en %>" >
+      <%= f.label :city, t(:city, scope: 'activerecord.attributes.profile').html_safe, id: "city_en", class: "tooltip", title: t(:city_tooltip, scope: 'activerecord.attributes.profile').html_safe %>
+      <%= f.text_field :city_en, as: :text, class: 'mb input--width-100', maxlength: '30' %>
       <%= f.label :twitter, id: "twitter_en", class: "mb input--width-100" %>
       <%= f.text_field :twitter_en, as: :text, placeholder: '@', class: "profile_twitter mb input--width-100", maxlength: 30 %>
       <%= f.label :website, id: "website_en", class: "mb input--width-100" %>

--- a/db/migrate/20170724190654_add_city_to_profile_translation.rb
+++ b/db/migrate/20170724190654_add_city_to_profile_translation.rb
@@ -1,0 +1,13 @@
+class AddCityToProfileTranslation < ActiveRecord::Migration
+  def change
+    reversible do |dir|
+      dir.up do
+        Profile.add_translation_fields!({city: :string}, {:migrate_data => true})
+      end
+
+      dir.down do
+        remove_column :profile_translations, :city
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170724190654) do
+ActiveRecord::Schema.define(version: 20170713124525) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -89,7 +89,6 @@ ActiveRecord::Schema.define(version: 20170724190654) do
     t.text     "bio"
     t.string   "twitter"
     t.string   "website"
-    t.string   "city"
   end
 
   add_index "profile_translations", ["locale"], name: "index_profile_translations_on_locale", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170713124525) do
+ActiveRecord::Schema.define(version: 20170725131924) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -76,6 +76,7 @@ ActiveRecord::Schema.define(version: 20170713124525) do
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
     t.integer  "position"
+    t.string   "language"
   end
 
   add_index "medialinks", ["profile_id"], name: "index_medialinks_on_profile_id", using: :btree
@@ -89,6 +90,7 @@ ActiveRecord::Schema.define(version: 20170713124525) do
     t.text     "bio"
     t.string   "twitter"
     t.string   "website"
+    t.string   "city"
   end
 
   add_index "profile_translations", ["locale"], name: "index_profile_translations_on_locale", using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170713124525) do
+ActiveRecord::Schema.define(version: 20170724190654) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -31,8 +31,8 @@ ActiveRecord::Schema.define(version: 20170713124525) do
 
   create_table "categories", force: true do |t|
     t.string   "name"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "categories_tags", force: true do |t|
@@ -45,10 +45,10 @@ ActiveRecord::Schema.define(version: 20170713124525) do
   add_index "categories_tags", ["tag_id"], name: "index_categories_tags_on_tag_id", using: :btree
 
   create_table "category_translations", force: true do |t|
-    t.integer  "category_id", null: false
+    t.integer  "category_id"
     t.string   "locale",      null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
     t.string   "name"
   end
 
@@ -73,23 +73,23 @@ ActiveRecord::Schema.define(version: 20170713124525) do
     t.text     "url"
     t.text     "title"
     t.text     "description"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
     t.integer  "position"
   end
 
   add_index "medialinks", ["profile_id"], name: "index_medialinks_on_profile_id", using: :btree
 
   create_table "profile_translations", force: true do |t|
-    t.integer  "profile_id", null: false
+    t.integer  "profile_id"
     t.string   "locale",     null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.string   "main_topic"
     t.text     "bio"
     t.string   "twitter"
-    t.string   "city"
     t.string   "website"
+    t.string   "city"
   end
 
   add_index "profile_translations", ["locale"], name: "index_profile_translations_on_locale", using: :btree
@@ -102,8 +102,8 @@ ActiveRecord::Schema.define(version: 20170713124525) do
     t.string   "languages"
     t.string   "city"
     t.string   "picture"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                             null: false
+    t.datetime "updated_at",                             null: false
     t.string   "encrypted_password",     default: "",    null: false
     t.string   "reset_password_token"
     t.datetime "reset_password_sent_at"

--- a/lib/tasks/city_translation.rake
+++ b/lib/tasks/city_translation.rake
@@ -1,0 +1,15 @@
+namespace :city_translation do
+  desc "copies city_en into city_de"
+  task copies_city: :environment do
+
+   Profile.all.each do |profile|
+      profile.city_de = profile.city_en
+      profile.save!
+      puts "#{profile.id}"
+      puts "city:   #{profile.city}"
+      puts "city_de:   #{profile.city_de}"
+      puts "city_en:   #{profile.city_en}"
+      puts "---------------------------------"
+   end
+  end
+end

--- a/spec/controllers/medialinks_controller_spec.rb
+++ b/spec/controllers/medialinks_controller_spec.rb
@@ -8,7 +8,7 @@ describe ProfilesController, type: :controller do
                                                           twitter: '@alove',
                                                           main_topic: 'first computer programm',
                                                           bio: 'first programmer',
-                                                          city: 'London',
+                                                          city_en: 'London',
                                                           country: 'GB',
                                                           iso_languages: ['en', 'fr'],
                                                           topic_list: 'algorithm, mathematic'

--- a/spec/features/adding_a_new_profile_spec.rb
+++ b/spec/features/adding_a_new_profile_spec.rb
@@ -20,7 +20,7 @@ describe "profile adding" do
     fill_in I18n.t(:firstname, scope: 'activerecord.attributes.profile'), with: 'Ada'
     fill_in I18n.t(:lastname, scope: 'activerecord.attributes.profile'), with: 'Lovelace'
     find(:css, "#twitter_en").set("@Lovelace")
-    find(:css, "#city").set("London")
+    find(:css, "#city_en").set("London")
 
     select "United Kingdom", from: I18n.t(:country, scope: 'activerecord.attributes.profile'), match: :first
     page.check I18n.t(:es, scope: 'iso_639_1').capitalize

--- a/spec/features/navigation_spec.rb
+++ b/spec/features/navigation_spec.rb
@@ -115,7 +115,7 @@ RSpec.feature 'Navigation', type: :feature do
         expect(page).to have_css('div.profile_firstname')
         expect(page).to have_css('div.profile_lastname')
         expect(page).to have_css('.profile_twitter')
-        expect(page).to have_css('div.profile_city')
+        expect(page).to have_css('#city_en')
         expect(page).to have_css('div.profile_iso_languages')
         expect(page).to have_css('.profile_website')
         expect(page).to have_css('div.profile_topic_list')

--- a/spec/models/concerns/searchable_spec.rb
+++ b/spec/models/concerns/searchable_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe Searchable, elasticsearch: true do
   let!(:profile) { FactoryGirl.create(:published, firstname: 'Ada', lastname: 'Lovelace',
                                       twitter_de: 'alovelace_de', twitter_en: 'alovelace',
-                                      city: 'London', country: 'GB',
+                                      city_de: 'London', city_en: 'London', country: 'GB',
                                       languages: 'English', iso_languages: ['en'],
                                       topic_list: ['ruby', 'algorithms'],
                                       bio_de: 'Das ist meine deutsche Bio.',
@@ -52,8 +52,8 @@ describe Searchable, elasticsearch: true do
       expect(profile.as_indexed_json['iso_languages']).to eq ['en']
     end
 
-    it 'contains the attribute city' do
-      expect(profile.as_indexed_json['city']).to eq 'London'
+    it 'contains the attribute cities' do
+      expect(profile.as_indexed_json['cities']).to eq ['London']
     end
 
     it 'contains the attribute country' do


### PR DESCRIPTION
#592 
@BriocheBerlin I finally decided only to adapt the cities method and keep the search index mapping as it is. So we get an array of [Berlin, Wien, Vienna] if a speaker has "Berlin, Wien" in her german profile and "Berlin, Vienna" in her english profile. 
This is probably confusing if the person that searches gets the same result while clicking on Vienna and on Wien. But I think it is better than restricting the results according to the locale. 