### PR TITLE
Cookies also available on staging

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -53,7 +53,7 @@ class ApplicationController < ActionController::Base
       cookies[:cookie_consent] = {
          value: true,
          expires: 1.year.from_now,
-         domain: :all
+         domain: (Rails.env.staging? ? nil : :all)
       }
       reset_session
     elsif !cookie_consent_given?


### PR DESCRIPTION
When we set the cookie in the controller we choose the option: `domain: all` which should work for all domains.

But on staging we have a special case. Our staging domain is: https://staging-speakerinnen-liste.herokuapp.com and according to the heroku docs all `herokuapp` domains with are excluded from the `all` option. See https://devcenter.heroku.com/articles/cookies-and-herokuapp-com

_`Herokuapp.com` is included in the Mozilla Foundation’s Public Suffix List. This list is used in recent versions of several browsers, such as Firefox, Chrome and Opera, to limit how broadly a cookie may be scoped. In other words, in browsers that support the functionality, applications in the herokuapp.com domain are prevented from setting cookies for *.herokuapp.com*_

So we have to make explicitly sure that in our staging environment we have no cookie domain. http://api.rubyonrails.org/classes/ActionDispatch/Cookies.html 