### PR TITLE
WIP add bullet for n+1 queries

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -56,4 +56,11 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   # config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.alert = true
+    Bullet.bullet_logger = true
+    Bullet.console = true
+    Bullet.rails_logger = true
+  end
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -117,11 +117,4 @@ SpeakerinnenListe::Application.configure do
     #:password => ENV['POSTMARK_API_TOKEN'],
     #:authentication => :plain
   #}
-  config.after_initialize do
-    Bullet.enable = true
-    Bullet.alert = true
-    Bullet.bullet_logger = true
-    Bullet.console = true
-    Bullet.rails_logger = true
-  end
 end

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -117,4 +117,11 @@ SpeakerinnenListe::Application.configure do
     #:password => ENV['POSTMARK_API_TOKEN'],
     #:authentication => :plain
   #}
+  config.after_initialize do
+    Bullet.enable = true
+    Bullet.alert = true
+    Bullet.bullet_logger = true
+    Bullet.console = true
+    Bullet.rails_logger = true
+  end
 end


### PR DESCRIPTION
Only for local development. https://www.sitepoint.com/silver-bullet-n1-problem/


Found already some n+1 cases:
```
user: tyranja
GET http://localhost:3000/de/categories/8
USE eager loading detected
  Profile => [:translations]
  Add to your finder: :includes => [:translations]
Call stack
  /home/tyranja/projects/speakerinnen_liste/app/models/profile.rb:93:in `main_topic_or_first_topic'
  /home/tyranja/projects/speakerinnen_liste/app/views/profiles/_profile_search.erb:10:in `_app_views_profiles__profile_search_erb__1877618236882118914_70148749564680'
  /home/tyranja/projects/speakerinnen_liste/app/views/profiles/index.html.erb:39:in `_app_views_profiles_index_html_erb__1111209811965776109_70148755475780'
```
```
user: tyranja
GET http://localhost:3000/de/categories/8
USE eager loading detected
  Profile => [:taggings]
  Add to your finder: :includes => [:taggings]
Call stack
  /home/tyranja/projects/speakerinnen_liste/app/models/profile.rb:93:in `main_topic_or_first_topic'
  /home/tyranja/projects/speakerinnen_liste/app/views/profiles/_profile_search.erb:10:in `_app_views_profiles__profile_search_erb__1877618236882118914_70148749564680'
  /home/tyranja/projects/speakerinnen_liste/app/views/profiles/index.html.erb:39:in `_app_views_profiles_index_html_erb__1111209811965776109_70148755475780'
```
```
user: tyranja
GET http://localhost:3000/de/categories/8
AVOID eager loading detected
  ActsAsTaggableOn::Tag => [:locale_languages]
  Remove from your finder: :includes => [:locale_languages]
Call stack
```