### PR TITLE
Anja improve cookie window

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -20,6 +20,66 @@ a, .link, #expander {
   }
 }
 
+.cookie_consent_detail {
+    display:none; 
+    height:auto;
+    margin:0;
+    float: left;
+}
+.show {
+    display: none; 
+}
+.hide:target + .show {
+    display: inline; 
+}
+.hide:target {
+    display: none; 
+}
+.hide:target ~ .cookie_consent_detail {
+    display:inline; 
+}
+
+/*style the (+) and (-) */
+.hide, .show {
+  width: 30px;
+  height: 30px;
+  border-radius: 30px;
+  font-size: 20px;
+  color: #fff;
+  text-shadow: 0 1px 0 #666;
+  text-align: center;
+  text-decoration: none;
+  box-shadow: 1px 1px 2px #000;
+  background: #cccbbb;
+  opacity: .95;
+  margin-right: 0;
+  float: left;
+  margin-bottom: 25px;
+}
+
+.hide:hover, .show:hover {
+  color: #eee;
+  text-shadow: 0 0 1px #666;
+  text-decoration: none;
+  box-shadow: 0 0 4px #222 inset;
+  opacity: 1;
+  margin-bottom: 25px;
+}
+
+.cookie_consent_detail p{
+    height:auto;
+    margin:0;
+}
+.cookie_consent_summary {
+  float: left;
+  height: auto;
+  width: 90%;
+  line-height: 20px;
+  padding-left: 20px;
+  margin-bottom: 25px;
+  font-style: italic;
+}
+
 h1, h4 {
   font-family: $serif;
 }
@@ -115,6 +175,7 @@ h1, h4 {
 
 /* cookie consent dialog */
 .cookie-consent-dialog {
+  height:auto !important; 
   position: fixed;
   bottom: 0px;
   z-index: 1;

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -20,66 +20,6 @@ a, .link, #expander {
   }
 }
 
-.cookie_consent_detail {
-    display:none; 
-    height:auto;
-    margin:0;
-    float: left;
-}
-.show {
-    display: none; 
-}
-.hide:target + .show {
-    display: inline; 
-}
-.hide:target {
-    display: none; 
-}
-.hide:target ~ .cookie_consent_detail {
-    display:inline; 
-}
-
-/*style the (+) and (-) */
-.hide, .show {
-  width: 30px;
-  height: 30px;
-  border-radius: 30px;
-  font-size: 20px;
-  color: #fff;
-  text-shadow: 0 1px 0 #666;
-  text-align: center;
-  text-decoration: none;
-  box-shadow: 1px 1px 2px #000;
-  background: #cccbbb;
-  opacity: .95;
-  margin-right: 0;
-  float: left;
-  margin-bottom: 25px;
-}
-
-.hide:hover, .show:hover {
-  color: #eee;
-  text-shadow: 0 0 1px #666;
-  text-decoration: none;
-  box-shadow: 0 0 4px #222 inset;
-  opacity: 1;
-  margin-bottom: 25px;
-}
-
-.cookie_consent_detail p{
-    height:auto;
-    margin:0;
-}
-.cookie_consent_summary {
-  float: left;
-  height: auto;
-  width: 90%;
-  line-height: 20px;
-  padding-left: 20px;
-  margin-bottom: 25px;
-  font-style: italic;
-}
-
 h1, h4 {
   font-family: $serif;
 }

--- a/app/views/shared/_auth_hint_modal.html.erb
+++ b/app/views/shared/_auth_hint_modal.html.erb
@@ -1,15 +1,10 @@
-<!-- Modal Contact -->
+<!-- Modal Auth -->
 <div class="modal fade" id="authModal" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title" id="ModalLabel">
-          <%= t(:hint, scope: 'pages.home' ) %>
-        </h5>
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
-      </div>
+      <button type="button" class="close text-right pr-2 pt-2" data-dismiss="modal" aria-label="Close">
+        <span aria-hidden="true">&times;</span>
+      </button>
       <div class="modal-body">
         <p><%= t(:auth_modal, scope: 'pages.home', link: privacy_path).html_safe %>
         <%= link_to(

--- a/app/views/shared/_contact_hint_modal.html.erb
+++ b/app/views/shared/_contact_hint_modal.html.erb
@@ -2,14 +2,9 @@
 <div class="modal fade" id="contactHint" tabindex="-1" role="dialog" aria-labelledby="exampleModalLabel" aria-hidden="true">
   <div class="modal-dialog" role="document">
     <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title" id="ModalLabel">
-          <%= t(:hint, scope: 'pages.home' ) %>
-        </h5>
-        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-          <span aria-hidden="true">&times;</span>
-        </button>
-      </div>
+      <button type="button" class="close text-right pr-2 pt-2" data-dismiss="modal" aria-label="Close">
+        <span aria-hidden="true">&times;</span>
+      </button>
       <div class="modal-body">
         <p><%= t(:contact_modal, scope: 'pages.home', link: privacy_path).html_safe %>
         <%= link_to(

--- a/app/views/shared/_cookie_consent.html.erb
+++ b/app/views/shared/_cookie_consent.html.erb
@@ -1,11 +1,19 @@
 <% if cookies[:cookie_consent].blank? %>
   <div class="cookie-consent-dialog alert-info alert clearfix">
-    <p><%= t(:cookie_consent, scope: 'pages.home', link: privacy_path).html_safe %>
+    <a href="#hide1" class="hide" id="hide1">++++</a>
+    <a href="#show1" class="show" id="show1">-----</a>
+    <div class="cookie_consent_summary"> 
+      <%= t(:cookie_consent_summary, scope: 'pages.home', link: privacy_path).html_safe %>
+    </div>
+    <div class="cookie_consent_detail">
+      <p>
+        <%= t(:cookie_consent_detail, scope: 'pages.home', link: privacy_path).html_safe %>
+      </p>
+    </div>
     <%= link_to(
       t(:allow_cookies, scope: 'pages.home'),
       url_for(params.permit!.merge(allow_cookies: true)),
       class: 'btn btn-light cookie-consent'
     ) %>
-    </p>
   </div>
 <% end %>

--- a/app/views/shared/_cookie_consent.html.erb
+++ b/app/views/shared/_cookie_consent.html.erb
@@ -1,19 +1,20 @@
 <% if cookies[:cookie_consent].blank? %>
   <div class="cookie-consent-dialog alert-info alert clearfix">
-    <a href="#hide1" class="hide" id="hide1">++++</a>
-    <a href="#show1" class="show" id="show1">-----</a>
-    <div class="cookie_consent_summary"> 
+    <div> 
       <%= t(:cookie_consent_summary, scope: 'pages.home', link: privacy_path).html_safe %>
+      <a class="text-white text-decoration-none" data-toggle="collapse" href="#collapseCookieDetail" role="button" aria-expanded="false" aria-controls="collapseCookieDetail">
+        <i class="fa fa-caret-down" style="font-size: 21px;"></i>
+      </a>
     </div>
-    <div class="cookie_consent_detail">
-      <p>
-        <%= t(:cookie_consent_detail, scope: 'pages.home', link: privacy_path).html_safe %>
-      </p>
+    <div class="collapse" id="collapseCookieDetail">
+      <hr>
+      <%= t(:cookie_consent_detail, scope: 'pages.home', link: privacy_path).html_safe %>
     </div>
+    <br>
     <%= link_to(
       t(:allow_cookies, scope: 'pages.home'),
       url_for(params.permit!.merge(allow_cookies: true)),
-      class: 'btn btn-light cookie-consent'
+      class: 'btn btn-light btn-sm cookie-consent'
     ) %>
   </div>
 <% end %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -50,7 +50,7 @@ Rails.application.configure do
   # Debug mode disables concatenation and preprocessing of assets.
   # This option may cause significant delays in view rendering with a large
   # number of complex assets.
-  config.assets.debug = true
+  config.assets.debug = false
 
   # config.action_mailer.delivery_method = :file
 

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -97,9 +97,10 @@ de:
       Mehr Informationen in unserer <a href='%{link}' class='link'>Datenschutzerklärung</a>.<br>"
       contact_modal: "Du musst der <b>Verwendung von Cookies zustimmen</b>, bevor Du das Kontaktformular benutzen kannst.<br>
       Mehr Informationen in unserer <a href='%{link}' class='link'>Datenschutzerklärung</a>.<br>"
-      cookie_consent: "Um unsere Seite nutzer*innenfreundlich zu gestalten und weiter
+      cookie_consent_summary: "Um unsere Seite nutzer*innenfreundlich zu gestalten und weiter
       verbessern zu können, speichern wir einzelne Informationen daüber, wie
-      sie genutzt wird. Das geschieht, indem wir einfache Textdateien, auch
+      sie genutzt wird." 
+      cookie_consent_detail: "Das geschieht, indem wir einfache Textdateien, auch
       Cookies genannt, durch das Aufrufen der Seite auf deinem Computer
       ablegen, wo sie dann gespeichert werden.
       <br> Wichtig: Bestimmte Funktionen können nur genutzt werden, wenn Du die

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -98,8 +98,7 @@ de:
       contact_modal: "Du musst der <b>Verwendung von Cookies zustimmen</b>, bevor Du das Kontaktformular benutzen kannst.<br>
       Mehr Informationen in unserer <a href='%{link}' class='link'>Datenschutzerklärung</a>.<br>"
       cookie_consent_summary: "Um unsere Seite nutzer*innenfreundlich zu gestalten und weiter
-      verbessern zu können, speichern wir einzelne Informationen daüber, wie
-      sie genutzt wird." 
+      verbessern zu können, speichern wir einzelne Informationen darüber, wie sie genutzt wird." 
       cookie_consent_detail: "Das geschieht, indem wir einfache Textdateien, auch
       Cookies genannt, durch das Aufrufen der Seite auf deinem Computer
       ablegen, wo sie dann gespeichert werden.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -95,7 +95,9 @@ en:
        Find more information about data security in our <a href='%{link}' class='link'>privacy policy</a>.<br>"
       contact_modal: "You have to <b>agree to the use of cookies</b>. before using the contact form.<br>
        Find more information about data security in our <a href='%{link}' class='link'>privacy policy</a>.<br>"
-      cookie_consent: "In order to deliver a personalised, responsive service and to improve the site, we remember and store information about how you use it. This is done using simple text files called cookies which sit on your computer. These cookies are completely safe and secure and will never contain any sensitive information. Important: To use the full functionality of this site (e.g. login, registration and sending mail to the speakers) you have to agree to the use of cookies. For web statistics we use Matomoto which also uses cookies. These can be deactivated separately. Find more information about data security in our <a href='%{link}' class='link'>privacy policy</a>."
+      cookie_consent_summary: "In order to deliver a personalised, responsive service and to improve the site, 
+      we remember and store information about how you use it." 
+      cookie_consent_detail: "This is done using simple text files called cookies which sit on your computer. These cookies are completely safe and secure and will never contain any sensitive information. Important: To use the full functionality of this site (e.g. login, registration and sending mail to the speakers) you have to agree to the use of cookies. For web statistics we use Matomoto which also uses cookies. These can be deactivated separately. Find more information about data security in our <a href='%{link}' class='link'>privacy policy</a>."
       allow_cookies: "I agree"
       description: "Our Categories"
       description_text: "We feel strongly about a balanced representation of men and women* on stage. We encourage women to become more visible in their profession and field of expertise."


### PR DESCRIPTION
- remove the header "Hint" in the modals because that is obvious
- change the cookie text to a shorter version which is visible per default and then you can click on a icon ( :small_red_triangle_down: )  to get the extended version of the cookie text