### PR TITLE
remove unused query and change count to size

### DIFF
--- a/app/controllers/admin/profiles_controller.rb
+++ b/app/controllers/admin/profiles_controller.rb
@@ -20,10 +20,6 @@ class Admin::ProfilesController < Admin::BaseController
   def show
     @medialinks = @profile.medialinks.order(:position)
     @message = Message.new
-    @topics = []
-    @topics << @profile.topics.with_language(I18n.locale)
-    @topics << @profile.topics.without_language
-    @topics = @topics.flatten.uniq
   end
 
   def edit

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -192,8 +192,7 @@ class ProfilesController < ApplicationController
     @category = Category.find(params[:category_id])
     @tags_in_category_published = ActsAsTaggableOn::Tag
                                   .belongs_to_category(params[:category_id])
-                                  .with_published_profile
-                                  .with_language(I18n.locale)
+                                  .translated_in_current_language_and_not_translated(I18n.locale)
     tag_names = @tags_in_category_published.pluck(:name)
     @tags_most_used_200_in_category = @tags_in_category_published.most_used(200)
     @profiles = profiles_for_tag(tag_names)

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -34,7 +34,6 @@ class ProfilesController < ApplicationController
                           else
                             ActsAsTaggableOn::Tag.with_published_profile.with_language(I18n.locale).most_used(200)
                           end
-    @tags_all = ActsAsTaggableOn::Tag.all
   end
 
   def show

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -43,10 +43,6 @@ class ProfilesController < ApplicationController
     else
       redirect_to profiles_url, notice: I18n.t('flash.profiles.show_no_permission')
     end
-    @topics = []
-    @topics << @profile.topics.with_language(I18n.locale)
-    @topics << @profile.topics.without_language
-    @topics = @topics.flatten.uniq
   end
 
   # should reuse the devise view

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -177,7 +177,7 @@ class ProfilesController < ApplicationController
   def profiles_for_tag(tag_names)
     Profile.is_published
            .random
-           .includes(:translations)
+           .includes(:taggings, :translations)
            .joins(:topics)
            .where(
              tags: {

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -33,7 +33,7 @@ module ApplicationHelper
     max_count = tags.pluck(:taggings_count).max.to_f
 
     tags.each do |tag|
-      index = ((tag.taggings.count / max_count) * (classes.size - 1))
+      index = ((tag.taggings.size / max_count) * (classes.size - 1))
       yield tag, classes[index.nan? ? 0 : index.round]
     end
   end

--- a/app/helpers/profiles_helper.rb
+++ b/app/helpers/profiles_helper.rb
@@ -26,10 +26,7 @@ module ProfilesHelper
     end
   end
 
-  def topics(profile)
-    topics = []
-    topics << profile.topics.with_language(I18n.locale)
-    topics << profile.topics.without_language
-    topics.flatten.uniq
+  def topics_for_profile(profile)
+    profile.topics.translated_in_current_language_and_not_translated(I18n.locale)
   end
 end

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -6,5 +6,5 @@ class Feature < ApplicationRecord
   translates :title, :description
   globalize_accessors :locales => [:de, :en], :attributes => [:title, :description]
 
-  scope :published_feature, -> { includes(profiles: :translations).where(public: true) }
+  scope :published_feature, -> { includes({ profiles: :translations }, { profiles: :taggings }, :translations).where(public: true) }
 end

--- a/app/views/profiles/_profile_search.erb
+++ b/app/views/profiles/_profile_search.erb
@@ -12,26 +12,26 @@
     </div>
 
     <div class="col-sm-12 col-md-8">
-     <% if profile.twitter.present? %>
-         <h5><%= t(:twitter, scope: 'profiles.show') %></h5>
-         <p class="pb-2">
-           <%=link_to '@' + profile.twitter_name_formatted, profile.twitter_link_formatted,
-           target: '_blank' %>
-         </p>
-     <% end %>
+      <% if profile.twitter.present? %>
+        <h5><%= t(:twitter, scope: 'profiles.show') %></h5>
+        <p class="pb-2">
+          <%=link_to '@' + profile.twitter_name_formatted, profile.twitter_link_formatted,
+          target: '_blank' %>
+        </p>
+      <% end %>
 
-     <% if profile.website.present? %>
-       <h5> <%= t(:website, scope: 'profiles.show') %> </h5>
-       <p class="pb-2">
-         <%= link_to profile.website, profile.website_with_protocol(profile.website),
+      <% if profile.website.present? %>
+        <h5> <%= t(:website, scope: 'profiles.show') %> </h5>
+        <p class="pb-2">
+          <%= link_to profile.website, profile.website_with_protocol(profile.website),
          target: '_blank' %>
-       </p>
-     <% end %>
+        </p>
+      <% end %>
 
-     <h5><%= t(:topics, scope: 'profiles.show') %></h5>
-     <p class="pb-2 topics-profile">
-       <%= raw topics(profile).map { |topic| topic_link(topic) }.join(' ') %>
-     </p>
+      <h5><%= t(:topics, scope: 'profiles.show') %></h5>
+      <p class="pb-2 topics-profile">
+        <%= raw topics_for_profile(profile).map { |topic| topic_link(topic) }.join(' ') %>
+      </p>
 
       <% if profile.iso_languages.present? %>
         <h5><%= t(:languages, scope: 'profiles.show') %></h5>

--- a/app/views/shared/_show.html.erb
+++ b/app/views/shared/_show.html.erb
@@ -87,7 +87,7 @@
         <p class="pb-1"></p>
     <% end %>
 
-    <% if @topics.present? %>
+    <% if @topics %>
       <h5><%= t(:topics, scope: 'profiles.show') %></h5>
       <p class="pb-2 topics-profile">
         <%= raw @topics.sort.map { |topic| topic_link(topic) }.join(' ') %>

--- a/app/views/shared/_show.html.erb
+++ b/app/views/shared/_show.html.erb
@@ -87,12 +87,10 @@
         <p class="pb-1"></p>
     <% end %>
 
-    <% if @topics %>
-      <h5><%= t(:topics, scope: 'profiles.show') %></h5>
-      <p class="pb-2 topics-profile">
-        <%= raw @topics.sort.map { |topic| topic_link(topic) }.join(' ') %>
-      </p>
-    <% end %>
+    <h5><%= t(:topics, scope: 'profiles.show') %></h5>
+    <p class="pb-2 topics-profile">
+      <%= raw topics_for_profile(@profile).map { |topic| topic_link(topic) }.join(' ') %>
+    </p>
 
     <% if @profile.iso_languages.present? %>
       <h5><%= t(:languages, scope: 'profiles.show') %></h5>

--- a/config/initializers/acts_as_taggable_on.rb
+++ b/config/initializers/acts_as_taggable_on.rb
@@ -19,7 +19,7 @@ ActsAsTaggableOn::Tag.class_eval do
 
   scope :with_language, -> (lang_str) { ActsAsTaggableOn::Tag.joins(:locale_languages).where(:locale_languages => {:iso_code => lang_str }).distinct }
 
-  scope :without_language, -> { ActsAsTaggableOn::Tag.includes(:locale_languages).where(locale_languages: { id: nil }).references(:locale_languages) }
+  scope :without_language, -> { ActsAsTaggableOn::Tag.left_outer_joins(:locale_languages).where(locale_languages: { id: nil }) }
 
   scope :with_published_profile, -> { ActsAsTaggableOn::Tag.joins(:taggings).joins("INNER JOIN profiles ON taggings.taggable_id=profiles.id").where(:profiles => { :published => true}).distinct }
 

--- a/config/initializers/acts_as_taggable_on.rb
+++ b/config/initializers/acts_as_taggable_on.rb
@@ -12,9 +12,9 @@ ActsAsTaggableOn::Tag.class_eval do
 
   # make sure that the joined table entry gets destroyed after deleting the tag
   #accepts_nested_attributes_for :tag_languages, allow_destroy: true
-  scope :translated_in_current_language_and_not_translated, -> (lang_str) { ActsAsTaggableOn::Tag.includes(:locale_languages)
+  scope :translated_in_current_language_and_not_translated, -> (lang_str) { ActsAsTaggableOn::Tag.left_outer_joins(:locale_languages)
                                                                 .where(locale_languages: { id: nil })
-                                                                .or( ActsAsTaggableOn::Tag.includes(:locale_languages)
+                                                                .or( ActsAsTaggableOn::Tag.left_outer_joins(:locale_languages)
                                                                 .where(:locale_languages => {:iso_code => lang_str }) ) }
 
   scope :with_language, -> (lang_str) { ActsAsTaggableOn::Tag.joins(:locale_languages).where(:locale_languages => {:iso_code => lang_str }).distinct }

--- a/config/initializers/acts_as_taggable_on.rb
+++ b/config/initializers/acts_as_taggable_on.rb
@@ -12,11 +12,10 @@ ActsAsTaggableOn::Tag.class_eval do
 
   # make sure that the joined table entry gets destroyed after deleting the tag
   #accepts_nested_attributes_for :tag_languages, allow_destroy: true
-  scope :translated_in_current_language_and_no_translation, -> (lang_str) { ActsAsTaggableOn::Tag.includes(:locale_languages)
+  scope :translated_in_current_language_and_not_translated, -> (lang_str) { ActsAsTaggableOn::Tag.includes(:locale_languages)
                                                                 .where(locale_languages: { id: nil })
                                                                 .or( ActsAsTaggableOn::Tag.includes(:locale_languages)
-                                                                .where(:locale_languages => {:iso_code => lang_str })
-                                                                .distinct ) }
+                                                                .where(:locale_languages => {:iso_code => lang_str }) ) }
 
   scope :with_language, -> (lang_str) { ActsAsTaggableOn::Tag.joins(:locale_languages).where(:locale_languages => {:iso_code => lang_str }).distinct }
 

--- a/config/initializers/acts_as_taggable_on.rb
+++ b/config/initializers/acts_as_taggable_on.rb
@@ -12,6 +12,11 @@ ActsAsTaggableOn::Tag.class_eval do
 
   # make sure that the joined table entry gets destroyed after deleting the tag
   #accepts_nested_attributes_for :tag_languages, allow_destroy: true
+  scope :translated_in_current_language_and_no_translation, -> (lang_str) { ActsAsTaggableOn::Tag.includes(:locale_languages)
+                                                                .where(locale_languages: { id: nil })
+                                                                .or(ActsAsTaggableOn::Tag.includes(:locale_languages)
+                                                                .where(:locale_languages => {:iso_code => lang_str })
+                                                                .distinct
 
   scope :with_language, -> (lang_str) { ActsAsTaggableOn::Tag.joins(:locale_languages).where(:locale_languages => {:iso_code => lang_str }).distinct }
 

--- a/config/initializers/acts_as_taggable_on.rb
+++ b/config/initializers/acts_as_taggable_on.rb
@@ -14,9 +14,9 @@ ActsAsTaggableOn::Tag.class_eval do
   #accepts_nested_attributes_for :tag_languages, allow_destroy: true
   scope :translated_in_current_language_and_no_translation, -> (lang_str) { ActsAsTaggableOn::Tag.includes(:locale_languages)
                                                                 .where(locale_languages: { id: nil })
-                                                                .or(ActsAsTaggableOn::Tag.includes(:locale_languages)
+                                                                .or( ActsAsTaggableOn::Tag.includes(:locale_languages)
                                                                 .where(:locale_languages => {:iso_code => lang_str })
-                                                                .distinct
+                                                                .distinct ) }
 
   scope :with_language, -> (lang_str) { ActsAsTaggableOn::Tag.joins(:locale_languages).where(:locale_languages => {:iso_code => lang_str }).distinct }
 


### PR DESCRIPTION
using some blogposts to refactor some queries:
https://www.speedshop.co/2019/01/10/three-activerecord-mistakes.html
https://www.justinweiss.com/articles/how-to-preload-rails-scopes/

https://blog.bigbinary.com/2016/05/30/rails-5-adds-or-support-in-active-record.html
https://solidfoundationwebdev.com/blog/posts/how-to-find-records-based-on-has_many-relationship-being-empty-or-not-in-rails
http://tomdallimore.com/blog/includes-vs-joins-in-rails-when-and-where/

for commit number: #69fe7d7 I used that very good explanation:
https://stackoverflow.com/questions/5319400/want-to-find-records-with-no-associated-records-in-rails-3#5570221

https://medium.com/@codenode/10-tips-for-eager-loading-to-avoid-n-1-queries-in-rails-2bad54456a3f