### PR TITLE
add documentation about excluding elasticsearch specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,9 @@ $ bundle exec rake db:test:clone
 
 # If tests are still failing, run:
 $ rails db:test:prepare
+
+# Run tests excluding elasticsearch specs, so without a running elasticsearch server
+$  bundle exec rspec spec --tag '~elasticsearch'
 ```
 
 # Please use Rubocop

--- a/spec/system/searching_for_profiles_spec.rb
+++ b/spec/system/searching_for_profiles_spec.rb
@@ -69,7 +69,7 @@ describe 'profile search' do
     end
   end
 
-  describe 'search in admin area' do
+  describe 'search in admin area', elasticsearch: true do
     before do
       sign_in admin
     end


### PR DESCRIPTION
Relates to issue #944 : specs apparently are tagged.  To exclude one needs to run `bundle exec rspec spec --tag '~elasticsearch'` . Info is added to README file 