### PR TITLE
Add profile image validation

### DIFF
--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -145,6 +145,10 @@ h1, h4 {
   background: $red;
 }
 
+.alert-error {
+  color: $red;
+}
+
 .border-vertical {
   border-top: $border;
   border-bottom: $border;

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -11,6 +11,7 @@ class Profile < ApplicationRecord
 
   serialize :iso_languages, Array
   validate :iso_languages_array_has_right_format
+  validate :image_format_size
   validates :profession, length: { maximum: 60, message: "Please use less than 80 characters." }
   before_save :clean_iso_languages!
 
@@ -168,6 +169,16 @@ class Profile < ApplicationRecord
 
     if iso_languages.map(&:class).uniq != [String]
       errors.add(:iso_languages, 'must be an array of strings')
+    end
+  end
+
+  def image_format_size
+    if image.attached?
+      if image.blob.byte_size > 1.megabyte
+        errors.add(:base, :file_size_too_big)
+      elsif !image.blob.content_type.starts_with?('image/')
+        errors.add(:base, :content_type_invalid)
+      end
     end
   end
 end

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,11 +1,8 @@
 <% if @profile.errors.any? %>
-  <div id="error_explanation">
-    <div class="alert alert-error">
-      The form contains <%= pluralize(@profile.errors.count, "error") %> <%= t ".not_saved" %>
-    </div>
-    <ul>
+  <div id="error_explanation" class="alert-error">
+    <ul class="list-group list-group-flush">
       <% @profile.errors.full_messages.each do |msg| %>
-        <li><%= msg %></li>
+        <li class="list-group-item"><%= msg %></li>
       <% end %>
     </ul>
   </div>

--- a/app/views/shared/_profile_formfields.html.erb
+++ b/app/views/shared/_profile_formfields.html.erb
@@ -1,16 +1,16 @@
 <div class="row">
   <div class="col-sm-12 col-md-6">
     <%= f.label :picture, t(:picture, scope: 'profiles.form').html_safe %>
-    <% if @profile.picture.present? %>
+    <!-- :image for active storage and :picture for carrierwave -->
+    <% if @profile.image.attached? && @profile.validate(:image_format_size) %>
+      <p><%= image_tag(@profile.image, class: "img-thumbnail") %></p>
+      <%= link_to t(:delete_picture, scope: 'profiles.form').html_safe, image_path(@profile.image.id), :method => :delete, data: { confirm: 'Are you sure?' } %>
+    <% elsif @profile.picture.present? %>
       <p><%= image_tag(@profile.picture_url, class: "img-thumbnail") %></p>
       <br>
       <%= f.check_box :remove_picture %>
       <%= t(:delete_picture, scope: 'profiles.form').html_safe %>
-    <% elsif @profile.image.attached? %>
-      <p><%= image_tag(@profile.image, class: "img-thumbnail") %></p>
-      <%= link_to t(:delete_picture, scope: 'profiles.form').html_safe, image_path(@profile.image.id), :method => :delete, data: { confirm: 'Are you sure?' } %>
     <% else %>
-      <!-- :picture for carrierwave and :image for active storage -->
       <p><%= f.file_field :image %></p>
       <small class="form-text text-muted">
         <%= t(:picture_info, scope: 'profiles.form').html_safe %><br>

--- a/config/locales/rails.de.yml
+++ b/config/locales/rails.de.yml
@@ -101,6 +101,8 @@ de:
       accepted: muss akzeptiert werden
       blank: muss ausgefüllt werden
       confirmation: stimmt nicht mit der Bestätigung überein
+      content_type_invalid: "Das Bild hat ein ungültiges Dateiformat. Es muss ein jpg, jpeg, gif oder png sein."
+      file_size_too_big: "Das Bild ist zu groß. Nur Bilder bis zu 1 MB sind erlaubt."
       empty: muss ausgefüllt werden
       equal_to: muss genau %{count} sein
       even: muss gerade sein

--- a/config/locales/rails.en.yml
+++ b/config/locales/rails.en.yml
@@ -101,6 +101,8 @@ en:
       accepted: must be accepted
       blank: can't be blank
       confirmation: doesn't match confirmation
+      content_type_invalid: "The image has an invalid content type. Needs to be a jpg, jpeg, gif or png."
+      file_size_too_big: "The image is too big. Only pictures up to 1 MB are allowed."
       empty: can't be empty
       equal_to: must be equal to %{count}
       even: must be even


### PR DESCRIPTION
I added validation for image size and format for the profile images in active storage. Until now it is mentioned, but the image is nevertheless uploaded, because active storage has no build in image validation. So, now an error is shown if the image is bigger then 1 MB or not an image format ... the only thing is, the error message is not really readable (do you see the white text inside the picture?)
![Screen Shot 2019-10-24 at 00 53 53](https://user-images.githubusercontent.com/372649/67440852-dd017480-f5fa-11e9-940b-bfa6c4acb4e7.png)
