### PR TITLE
Use pagy instead of kaminari (in progress) #914

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'normalize-rails'
 gem 'deadweight', require: 'deadweight/hijack/rails'
 
 gem 'kaminari'
+gem 'pagy'
 gem 'mime-types'
 
 gem 'acts-as-taggable-on', '~> 6.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -510,6 +510,7 @@ GEM
     os (1.0.0)
     ovirt-engine-sdk (4.2.5)
       json (>= 1, < 3)
+    pagy (3.7.0)
     parallel (1.12.1)
     parser (2.5.3.0)
       ast (~> 2.4.0)
@@ -738,6 +739,7 @@ DEPENDENCIES
   minitest (= 5.11.3)
   normalize-rails
   omniauth-twitter
+  pagy
   pg (~> 1.1.3)
   poltergeist (= 1.18.1)
   pry

--- a/app/assets/stylesheets/custom.scss
+++ b/app/assets/stylesheets/custom.scss
@@ -296,6 +296,7 @@ ul#medialinks__list {
 .pagination {
   text-align: center;
   display: block;
+  padding: 20px;
 }
 
 .pagination ul {

--- a/app/controllers/admin/profiles_controller.rb
+++ b/app/controllers/admin/profiles_controller.rb
@@ -6,11 +6,11 @@ class Admin::ProfilesController < Admin::BaseController
   before_action :set_profile, only: %i[show edit update destroy publish unpublish admin_update]
 
   def index
-    @profiles = if params[:search]
-                  Profile.is_confirmed.admin_search(params[:search]).order('profiles.created_at DESC').page(params[:page]).per(100)
-                else
-                  Profile.is_confirmed.order(sort_column + ' ' + sort_direction).order('created_at DESC').page(params[:page]).per(100)
-                end
+    @pagy, @profiles = if params[:search]
+                         pagy(Profile.is_confirmed.admin_search(params[:search]).order('profiles.created_at DESC'), items: 100)
+                       else
+                         pagy(Profile.is_confirmed.order(sort_column + ' ' + sort_direction).order('created_at DESC'), items: 100)
+                       end
   end
 
   def new; end

--- a/app/controllers/admin/tags_controller.rb
+++ b/app/controllers/admin/tags_controller.rb
@@ -40,11 +40,9 @@ class Admin::TagsController < Admin::BaseController
   def index
     @categories = Category.all.includes(:translations)
     @tags_count = ActsAsTaggableOn::Tag.count
-    @tags = TagFilter.new(ActsAsTaggableOn::Tag.all.includes(:tags_locale_languages, :actsastaggableon_tags_categories, :taggings), filter_params)
+    @pagy, @tags = pagy(TagFilter.new(ActsAsTaggableOn::Tag.all.includes(:tags_locale_languages, :actsastaggableon_tags_categories, :taggings), filter_params)
                      .filter
-                     .order(sort_column + ' ' + sort_direction)
-                     .page(params[:page])
-                     .per(20)
+                     .order(sort_column + ' ' + sort_direction), items: 20)
     session[:filter_params] = filter_params
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
+  include Pagy::Backend
+
   protect_from_forgery
 
   before_action :set_locale

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  include Pagy::Frontend
+
   def devise_mapping
     Devise.mappings[:profile]
   end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -3,6 +3,7 @@ class Profile < ApplicationRecord
   include HasPicture
   include Searchable
   include ActiveModel::Serialization
+  extend Pagy::Search
 
   has_many :medialinks
   has_many :feature_profiles

--- a/app/views/admin/profiles/index.html.erb
+++ b/app/views/admin/profiles/index.html.erb
@@ -6,13 +6,13 @@
   </div>
 
   <%= form_tag(admin_profiles_path, method: 'get', class:'mt-3 form-row') do %>
-      <div class="col-md-6 mb-4">
+      <div class="col-md-6">
         <%= text_field_tag :search, params[:search], class: "form-control", id: "formGroupExampleInput", placeholder: t(:search, scope: 'admin.profiles') %>
       </div>
     <%= submit_tag t(:search, scope: 'general'), class: 'btn btn-blue' %>
   <% end %>
 
-  <%= paginate @profiles %>
+  <%== pagy_bootstrap_nav(@pagy) %>
 
   <table class="table">
     <thead class="bg--lightgrey">
@@ -68,5 +68,6 @@
     </tbody>
   </table>
 
-  <%= paginate @profiles %>
+  <%== pagy_bootstrap_nav(@pagy) %>
+
 </div>

--- a/app/views/admin/tags/index.html.erb
+++ b/app/views/admin/tags/index.html.erb
@@ -3,14 +3,14 @@
 
   <div class="font-weight-bold text-center border-top pt-3">
     <% if @tags_count %>
-    <%= t(:tags_here_are, scope: 'admin.tags') + @tags.total_count.to_s + t(:tags_of, scope: 'admin.tags') + @tags_count.to_s + ' tags.' %>
+    <%= t(:tags_here_are, scope: 'admin.tags') + @pagy.count.to_s + t(:tags_of, scope: 'admin.tags') + @tags_count.to_s + ' tags.' %>
     <% else %>
-    <%= t(:tags_count, scope: 'admin.tags') + @tags.total_count.to_s + '.' %>
+    <%= t(:tags_count, scope: 'admin.tags') + @pagy.count.to_s + '.' %>
     <% end %>
   </div>
 
   <div class="text-center">
-    <%= paginate @tags %>
+    <%== pagy_bootstrap_nav(@pagy) %>
   </div>
 
   <div class="row">
@@ -73,6 +73,6 @@
   </div>
 
   <div class="text-center">
-    <%= paginate @tags %>
+    <%== pagy_bootstrap_nav(@pagy) %>
   </div>
 </div>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -7,18 +7,18 @@
       <% if params[:category_id] %> <%# when in categories scope %>
         <%= link_to t(:category, scope: 'profiles',
             category_name: @category.name,
-            profiles_count: @profiles.total_count,
+            profiles_count: @pagy.count,
             topics_count: @tags_in_category_published.size
           ).html_safe, '#speakers', class: 'h4' %>
       <% elsif params[:topic] %> <%# when in topic scope %>
         <%= link_to t(:profiles_topics, scope: 'search',
-            profiles_count: @profiles.total_count,
+            profiles_count: @pagy.count,
             topics_name: params[:topic]).html_safe,
             '#speakers', class: 'h4' %>
       <% elsif params[:search] %> <%# if in search: %>
         <%= link_to t(:success, scope: 'search' ).html_safe +
                     t(:result, scope: 'search',
-                    count: @profiles.total_count).html_safe,
+                    count: @pagy.count).html_safe,
                     '#speakers', class: 'h4' %>
       <% else %>
         <h4><%= t(:all_speakerinnen, scope: 'profiles.index', profiles_count: @profiles_count).html_safe %></h4>
@@ -45,11 +45,11 @@
 
 
   <a id="speakers"></a>
-  <%= paginate @profiles %>
+  <%== pagy_bootstrap_nav(@pagy) %>
 
   <%= render partial: 'profiles/profile_search', collection: @profiles, as: :profile %>
 
-  <%= paginate @profiles %>
+  <%== pagy_bootstrap_nav(@pagy) %>
 
   <a id="tag_cloud_anchor"></a>
   <h5 class="text-center"><%= t(:more_options, scope: 'search').html_safe %></h5>

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,0 +1,170 @@
+# encoding: utf-8
+# frozen_string_literal: true
+
+# Pagy initializer file (3.7.0)
+# Customize only what you really need and notice that Pagy works also without any of the following lines.
+# Should you just cherry pick part of this file, please maintain the require-order of the extras
+
+
+# Extras
+# See https://ddnexus.github.io/pagy/extras
+
+
+# Backend Extras
+
+# Array extra: Paginate arrays efficiently, avoiding expensive array-wrapping and without overriding
+# See https://ddnexus.github.io/pagy/extras/array
+# require 'pagy/extras/array'
+
+# Countless extra: Paginate without any count, saving one query per rendering
+# See https://ddnexus.github.io/pagy/extras/countless
+# require 'pagy/extras/countless'
+# Pagy::VARS[:cycle] = false    # default
+
+# Elasticsearch Rails extra: Paginate `ElasticsearchRails::Results` objects
+# See https://ddnexus.github.io/pagy/extras/elasticsearch_rails
+# require 'pagy/extras/elasticsearch_rails'
+
+# Searchkick extra: Paginate `Searchkick::Results` objects
+# See https://ddnexus.github.io/pagy/extras/searchkick
+# require 'pagy/extras/searchkick'
+
+
+# Frontend Extras
+
+# Bootstrap extra: Add nav, nav_js and combo_nav_js helpers and templates for Bootstrap pagination
+# See https://ddnexus.github.io/pagy/extras/bootstrap
+require 'pagy/extras/bootstrap'
+
+# Bulma extra: Add nav, nav_js and combo_nav_js helpers and templates for Bulma pagination
+# See https://ddnexus.github.io/pagy/extras/bulma
+# require 'pagy/extras/bulma'
+
+# Foundation extra: Add nav, nav_js and combo_nav_js helpers and templates for Foundation pagination
+# See https://ddnexus.github.io/pagy/extras/foundation
+# require 'pagy/extras/foundation'
+
+# Materialize extra: Add nav, nav_js and combo_nav_js helpers for Materialize pagination
+# See https://ddnexus.github.io/pagy/extras/materialize
+# require 'pagy/extras/materialize'
+
+# Navs extra: Add nav_js and combo_nav_js javascript helpers
+# Notice: the other frontend extras add their own framework-styled versions,
+# so require this extra only if you need the unstyled version
+# See https://ddnexus.github.io/pagy/extras/navs
+# require 'pagy/extras/navs'
+
+# Semantic extra: Add nav, nav_js and combo_nav_js helpers for Semantic UI pagination
+# See https://ddnexus.github.io/pagy/extras/semantic
+# require 'pagy/extras/semantic'
+
+# UIkit extra: Add nav helper and templates for UIkit pagination
+# See https://ddnexus.github.io/pagy/extras/uikit
+# require 'pagy/extras/uikit'
+
+# Multi size var used by the *_nav_js helpers
+# See https://ddnexus.github.io/pagy/extras/navs#steps
+# Pagy::VARS[:steps] = { 0 => [2,3,3,2], 540 => [3,5,5,3], 720 => [5,7,7,5] }   # example
+
+
+# Feature Extras
+
+# Headers extra: http response headers (and other helpers) useful for API pagination
+# See http://ddnexus.github.io/pagy/extras/headers
+# require 'pagy/extras/headers'
+# Pagy::VARS[:headers] = { page: 'Current-Page', items: 'Page-Items', count: 'Total-Count', pages: 'Total-Pages' }     # default
+
+# Support extra: Extra support for features like: incremental, infinite, auto-scroll pagination
+# See https://ddnexus.github.io/pagy/extras/support
+# require 'pagy/extras/support'
+
+# Items extra: Allow the client to request a custom number of items per page with an optional selector UI
+# See https://ddnexus.github.io/pagy/extras/items
+# require 'pagy/extras/items'
+# Pagy::VARS[:items_param] = :items    # default
+# Pagy::VARS[:max_items]   = 100       # default
+
+# Overflow extra: Allow for easy handling of overflowing pages
+# See https://ddnexus.github.io/pagy/extras/overflow
+# require 'pagy/extras/overflow'
+# Pagy::VARS[:overflow] = :empty_page    # default  (other options: :last_page and :exception)
+
+# Metadata extra: Provides the pagination metadata to Javascript frameworks like Vue.js, react.js, etc.
+# See https://ddnexus.github.io/pagy/extras/metadata
+# you must require the shared internal extra (BEFORE the metadata extra) ONLY if you need also the :sequels
+# require 'pagy/extras/shared'
+# require 'pagy/extras/metadata'
+# For performance reason, you should explicitly set ONLY the metadata you use in the frontend
+# Pagy::VARS[:metadata] = [:scaffold_url, :count, :page, :prev, :next, :last]    # example
+
+# Trim extra: Remove the page=1 param from links
+# See https://ddnexus.github.io/pagy/extras/trim
+# require 'pagy/extras/trim'
+
+
+
+# Pagy Variables
+# See https://ddnexus.github.io/pagy/api/pagy#variables
+# All the Pagy::VARS are set for all the Pagy instances but can be overridden
+# per instance by just passing them to Pagy.new or the #pagy controller method
+
+
+# Instance variables
+# See https://ddnexus.github.io/pagy/api/pagy#instance-variables
+# Pagy::VARS[:items] = 20                                   # default
+
+
+# Other Variables
+# See https://ddnexus.github.io/pagy/api/pagy#other-variables
+# Pagy::VARS[:size]       = [1,4,4,1]                       # default
+# Pagy::VARS[:page_param] = :page                           # default
+# Pagy::VARS[:params]     = {}                              # default
+# Pagy::VARS[:anchor]     = '#anchor'                       # example
+# Pagy::VARS[:link_extra] = 'data-remote="true"'            # example
+
+
+# Rails
+
+# Rails: extras assets path required by the helpers that use javascript
+# (pagy*_nav_js, pagy*_combo_nav_js, and pagy_items_selector_js)
+# See https://ddnexus.github.io/pagy/extras#javascript
+# Rails.application.config.assets.paths << Pagy.root.join('javascripts')
+
+
+# I18n
+
+# Pagy internal I18n: ~18x faster using ~10x less memory than the i18n gem
+# See https://ddnexus.github.io/pagy/api/frontend#i18n
+# Notice: No need to configure anything in this section if your app uses only "en"
+# or if you use the i18n extra below
+#
+# Examples:
+# load the "de" built-in locale:
+# Pagy::I18n.load(locale: 'de')
+#
+# load the "de" locale defined in the custom file at :filepath:
+# Pagy::I18n.load(locale: 'de', filepath: 'path/to/pagy-de.yml')
+#
+# load the "de", "en" and "es" built-in locales:
+# (the first passed :locale will be used also as the default_locale)
+# Pagy::I18n.load({locale: 'de'},
+#                 {locale: 'en'},
+#                 {locale: 'es'})
+#
+# load the "en" built-in locale, a custom "es" locale,
+# and a totally custom locale complete with a custom :pluralize proc:
+# (the first passed :locale will be used also as the default_locale)
+# Pagy::I18n.load({locale: 'en'},
+#                 {locale: 'es', filepath: 'path/to/pagy-es.yml'},
+#                 {locale: 'xyz',  # not built-in
+#                  filepath: 'path/to/pagy-xyz.yml',
+#                  pluralize: lambda{|count| ... } )
+
+
+# I18n extra: uses the standard i18n gem which is ~18x slower using ~10x more memory
+# than the default pagy internal i18n (see above)
+# See https://ddnexus.github.io/pagy/extras/i18n
+# require 'pagy/extras/i18n'
+
+# Default i18n key
+# Pagy::VARS[:i18n_key] = 'pagy.item_name'   # default

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -14,7 +14,7 @@
 
 # Array extra: Paginate arrays efficiently, avoiding expensive array-wrapping and without overriding
 # See https://ddnexus.github.io/pagy/extras/array
-# require 'pagy/extras/array'
+require 'pagy/extras/array'
 
 # Countless extra: Paginate without any count, saving one query per rendering
 # See https://ddnexus.github.io/pagy/extras/countless
@@ -23,7 +23,7 @@
 
 # Elasticsearch Rails extra: Paginate `ElasticsearchRails::Results` objects
 # See https://ddnexus.github.io/pagy/extras/elasticsearch_rails
-# require 'pagy/extras/elasticsearch_rails'
+require 'pagy/extras/elasticsearch_rails'
 
 # Searchkick extra: Paginate `Searchkick::Results` objects
 # See https://ddnexus.github.io/pagy/extras/searchkick


### PR DESCRIPTION
Issue:  #914
When I use the Pagy Extra for ElasticSearch, the Active Mode ([https://ddnexus.github.io/pagy/extras/elasticsearch_rails](url)), and try to make a search, I get this error:
![Captura de tela de 2019-12-05 18-17-26](https://user-images.githubusercontent.com/42655535/70275250-886e1f00-178c-11ea-8fb3-822e17cf7f73.png)

I also tried to use the Passive mode, and got the same error.

