### PR TITLE
Activate Devise.paranoid mode to avoid user enumeration attacks

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -71,7 +71,7 @@ Devise.setup do |config|
   # It will change confirmation, password recovery and other workflows
   # to behave the same regardless if the e-mail provided was right or wrong.
   # Does not affect registerable.
-  # config.paranoid = true
+  config.paranoid = true
 
   # By default Devise will store the user in session. You can skip storage for
   # :http_auth and :token_auth by adding those symbols to the array below.


### PR DESCRIPTION
This resolves #993. Here's what the page looks like after submitting the "forgot password" form:

<img width="1440" alt="Screenshot 2020-01-30 at 18 51 09" src="https://user-images.githubusercontent.com/451791/73476234-2992e380-4392-11ea-9a29-711a6a68b5f6.png">
