### PR TITLE
Apply suggestions from bullet gem logs to eager load image attachments on the profiles index page

### DIFF
--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -36,6 +36,7 @@
     <%= render partial: 'shared/search_filter',
       locals: {
         profiles: @profiles,
+        profiles_for_pagination: @profiles_for_pagination,
         aggs_languages: @aggs_languages,
         aggs_countries: @aggs_countries,
         aggs_cities: @aggs_cities

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -7,18 +7,18 @@
       <% if params[:category_id] %> <%# when in categories scope %>
         <%= link_to t(:category, scope: 'profiles',
             category_name: @category.name,
-            profiles_count: @profiles.total_count,
+            profiles_count: @profiles_for_pagination.total_count,
             topics_count: @tags_in_category_published.size
           ).html_safe, '#speakers', class: 'h4' %>
       <% elsif params[:topic] %> <%# when in topic scope %>
         <%= link_to t(:profiles_topics, scope: 'search',
-            profiles_count: @profiles.total_count,
+            profiles_count: @profiles_for_pagination.total_count,
             topics_name: params[:topic]).html_safe,
             '#speakers', class: 'h4' %>
       <% elsif params[:search] %> <%# if in search: %>
         <%= link_to t(:success, scope: 'search' ).html_safe +
                     t(:result, scope: 'search',
-                    count: @profiles.total_count).html_safe,
+                    count: @profiles_for_pagination.total_count).html_safe,
                     '#speakers', class: 'h4' %>
       <% else %>
         <h4><%= t(:all_speakerinnen, scope: 'profiles.index', profiles_count: @profiles_count).html_safe %></h4>
@@ -45,11 +45,11 @@
 
 
   <a id="speakers"></a>
-  <%= paginate @profiles %>
+  <%= paginate @profiles_for_pagination %>
 
   <%= render partial: 'profiles/profile_search', collection: @profiles, as: :profile %>
 
-  <%= paginate @profiles %>
+  <%= paginate @profiles_for_pagination %>
 
   <a id="tag_cloud_anchor"></a>
   <h5 class="text-center"><%= t(:more_options, scope: 'search').html_safe %></h5>

--- a/app/views/shared/_search_filter.erb
+++ b/app/views/shared/_search_filter.erb
@@ -17,7 +17,7 @@
             <b><%= t(:countries_agg, scope: 'search' ).html_safe%></b>
             <% aggs_countries[0..9].each do |term| %>
               <li class='pl-1 <%= 'selected' if params[:filter_countries] == term['key'] %>'>
-                <%= link_to ISO3166::Country.find_country_by_alpha2("#{term['key']}").translation(I18n.locale), {search: params[:search], filter_countries: term['key']}, 
+                <%= link_to ISO3166::Country.find_country_by_alpha2("#{term['key']}").translation(I18n.locale), {search: params[:search], filter_countries: term['key']},
                 class: "#{'bg-dark text-light' if params[:filter_countries] == term['key'] }" %>
                 <small class="pl-1"><%= term['doc_count'] %></small>
               </li>
@@ -29,8 +29,8 @@
               <% display_value = aggs_countries[10..999] == [] ? "block" : "none" %>
               <% aggs_countries[10..999].each do |term| %>
                 <li class='pl-1 rest_facet_countries <%= 'selected' if params[:filter_countries] == term['key'] %>' style='display: <%= display_value %>;'>
-                  <%= link_to ISO3166::Country.find_country_by_alpha2("#{term['key']}").translation(I18n.locale), 
-                    {search: params[:search], filter_countries: term['key']}, 
+                  <%= link_to ISO3166::Country.find_country_by_alpha2("#{term['key']}").translation(I18n.locale),
+                    {search: params[:search], filter_countries: term['key']},
                     class: "#{'bg-dark text-light' if params[:filter_countries] == term['key'] }" %>
                   <small class="pl-1"><%= term['doc_count'] %></small>
                 </li>
@@ -47,7 +47,7 @@
           <b><%=t(:cities_agg, scope: 'search' ).html_safe%></b>
             <% aggs_cities[0..9].each do |term| %>
               <li class='pl-1 <%= 'selected' if params[:filter_cities] == term['key'] %>'>
-                <%= link_to term['key'], { search: params[:search], filter_cities: term['key']}, 
+                <%= link_to term['key'], { search: params[:search], filter_cities: term['key']},
                 class: "#{'bg-dark text-light' if params[:filter_cities] == term['key'] }"  %>
                 <small class="pl-1"><%= term['doc_count'] %></small>
               </li>
@@ -59,7 +59,7 @@
               <% display_value = aggs_cities[10..999] == [] ? "block" : "none" %>
               <% aggs_cities[10..999].each do |term| %>
                 <li class='pl- rest_facet_cities <%= 'selected' if params[:filter_cities] == term['key'] %>' style='display: <%= display_value %>;'>
-                  <%= link_to term['key'],{ search: params[:search], filter_cities: term['key'] }, 
+                  <%= link_to term['key'],{ search: params[:search], filter_cities: term['key'] },
                   class: "#{'bg-dark text-light' if params[:filter_cities] == term['key'] }" %>
                   <small class="pl-1"><%= term['doc_count'] %></small>
                 </li>
@@ -78,9 +78,9 @@
             <% aggs_languages[0..9].each do |term| %>
             <li class='pl-1 <%= 'selected' if params[:filter_lang] == term['key'] %>'>
               <%= link_to t("#{term['key']}", scope: 'iso_639_1').capitalize,
-              {search: params[:search], filter_lang: term['key']}, 
+              {search: params[:search], filter_lang: term['key']},
               class: "#{'bg-dark text-light' if params[:filter_lang] == term['key'] }" %>
-              <small class="pl-1"><%= term['doc_count'] %></small>                
+              <small class="pl-1"><%= term['doc_count'] %></small>
             </li>
             <% end %>
             <% if aggs_languages.length > 10 %>
@@ -89,8 +89,8 @@
               <% display_value = aggs_languages[10..999] == [] ? "block" : "none" %>
               <% aggs_languages[10..999].each do |term| %>
                 <li class='pl- rest_facet_languages <%= 'selected' if params[:filter_cities] == term['key'] %>' style='display: <%= display_value %>;'>
-                  <%= link_to t("#{term['key']}", scope: 'iso_639_1').capitalize , 
-                  {search: params[:search], filter_lang: term['key']}, 
+                  <%= link_to t("#{term['key']}", scope: 'iso_639_1').capitalize ,
+                  {search: params[:search], filter_lang: term['key']},
                   class: "#{'bg-dark text-light' if params[:filter_lang] == term['key'] }" %>
                   <small class="pl-1"><%= term['doc_count'] %></small>
                 </li>
@@ -106,9 +106,9 @@
 
 <% elsif profiles.size < 1 %>
 
-  <% if params[:search].present? && profiles.response.response.suggest.did_you_mean_fullname.first.options.present? %>
+  <% if params[:search].present? && profiles_for_pagination.response.response.suggest.did_you_mean_fullname.first.options.present? %>
     <p class="py-5">
-      <%= t(:did_you_mean, scope: 'search', suggestions_fullname: profiles.response.response.suggest.did_you_mean_fullname.first.options.map {|sug| link_to(sug.text.capitalize, "profiles?&search=#{sug.text}")} * ", " ).html_safe %>
+      <%= t(:did_you_mean, scope: 'search', suggestions_fullname: profiles_for_pagination.response.response.suggest.did_you_mean_fullname.first.options.map {|sug| link_to(sug.text.capitalize, "profiles?&search=#{sug.text}")} * ", " ).html_safe %>
     </p>
   <% elsif params[:search].blank? %>
     <p class="py-5">


### PR DESCRIPTION
This resolves n+1 queries problem in issue #724, on the profiles index page, specifically for eagerly loading the images. There's still an n+1 queries problem with the topics' translations loading, as described in the issue.