### PR TITLE
Bug fix: use 'total' instead of 'count' to show total number of search results, instead of just current page

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -22,10 +22,9 @@ class ProfilesController < ApplicationController
     #   profiles_for_category(params[:category_id], params[:tag_filter])
     #   @profiles_count = @profiles.total_count
     if params[:search]
-      @profiles_for_search= profiles_for_search
-      @profiles = @profiles_for_search
+      @profiles = profiles_for_search
       # sum of search results concerning certain attributes
-      @aggs = profiles_for_search.response.aggregations
+      @aggs = @profiles.response.aggregations
       @aggs_languages = @aggs[:lang][:buckets]
       @aggs_cities = @aggs[:city][:buckets]
       @aggs_countries = @aggs[:country][:buckets]

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -5,13 +5,13 @@
     <div class="row">
       <div class="col-12 py-5">
         <span class="h1">
-          <%= t(:success, scope: 'search').html_safe + t(:result, scope: 'search', count: @profiles_for_search.count).html_safe %><b><%= params[:search] if params[:search] %></b>
+          <%= t(:success, scope: 'search').html_safe + t(:result, scope: 'search', count: @profiles.total).html_safe %><b><%= params[:search] if params[:search] %></b>
         </span>
         <span class="float-right"><%= link_to("<i class='fa fa-filter pr-2'></i>".html_safe + "Filter by themes", profiles_path, class: '')  %>
         </span>
       </div>
     </div>
-    <% if @profiles_for_search.count > 0 %>
+    <% if @profiles.count > 0 %>
       <div class="row-3">
         <div class="col-12">
           <%= render partial: 'shared/search_filter',


### PR DESCRIPTION
`.count` gives the number of results for the current page, while `.total` is an ElasticSearch attributes which gives the total number of results.

While at it, I also simplified the usage of variables a little bit.