### PR TITLE
Move error message for form to right-hand side of input label

### DIFF
--- a/app/views/contact/_form.html.erb
+++ b/app/views/contact/_form.html.erb
@@ -1,9 +1,9 @@
 <%= simple_form_for @message, url: url, html: {id: ""} do |f| %>
-  <%= f.input :name, as: :string, required: false, label: t(".name"), input_html: { class: 'form-control mb-3' }  %>
-  <%= f.input :email, label: t(".email"), required: false, input_html: { class: 'form-control mb-3' }   %>
+  <%= f.input :name, as: :string, required: false, label: t(".name"), input_html: { class: 'form-control mb-3' }, error_html: { style: 'float:right'} %>
+  <%= f.input :email, label: t(".email"), required: false, input_html: { class: 'form-control mb-3' }, error_html: { style: 'float:right'} %>
   <%= invisible_captcha %>
-  <%= f.input :subject, label: t(".subject"), required: false, input_html: { class: 'form-control mb-3' }   %>
-  <%= f.input :body, as: :text, label: t(".body"), required: false, input_html: { class: 'form-control mb-3' }   %>
+  <%= f.input :subject, label: t(".subject"), required: false, input_html: { class: 'form-control mb-3' }, error_html: { style: 'float:right'} %>
+  <%= f.input :body, as: :text, label: t(".body"), required: false, input_html: { class: 'form-control mb-3' }, error_html: { style: 'float:right'} %>
 
   <div class="modal-footer">
     <%= f.submit t(".send"), class: "btn btn-primary"%>

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -8,9 +8,10 @@ SimpleForm.setup do |config|
     b.optional :min_max
     b.optional :readonly
 
-    b.use :label_input
+    b.use :label
+    b.use :error, wrap_with: { tag: :span, class: :error }    
+    b.use :input
     b.use :hint,  wrap_with: { tag: :span }
-    b.use :error, wrap_with: { tag: :span, class: :error }
   end
 
   config.label_text = proc { |label, required| "#{label}" }


### PR DESCRIPTION
This PR fixes issue: https://github.com/rubymonsters/speakerinnen_liste/issues/951

Hello! 👋 😄 

I've split the `label_input` component in the simple_form config into a `label` component and an `input` component. I then moved the `error` component underneath the `label` component so they are now next to each other.

I also gave each error a `float:right` style so that the error is not immediately next to the label text. It now looks like this:
![image](https://user-images.githubusercontent.com/27900457/78990161-ab8b4f80-7b2d-11ea-888f-ce6958533193.png)

I can't think of how to test this 🤔 Do you think it needs a test?

Also, I ran rubocop but it seems to check only 3 files:
![image](https://user-images.githubusercontent.com/27900457/78990241-decdde80-7b2d-11ea-9f32-fceabf284453.png)
Is this intentional?

Looking forward to your feedback!