### PR TITLE
Redirect back to homepage when person cancels twitter signin

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -13,4 +13,8 @@ class OmniauthCallbacksController < ApplicationController
   end
 
   alias twitter all
+
+  def failure
+    redirect_to root_path
+  end
 end


### PR DESCRIPTION
Fixes #271 

I'm fairly certain this works. It was a bit hard for me to test, because when running locally, the twitter sign-in didn't work well. It would be good to have another person test this.