### PR TITLE
Change CSS classes of the homepage search line

### DIFF
--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -8,7 +8,7 @@
         </div>
       </div>
       <div class="row">
-        <div class="col-lg-6 col-dm-12 ml-2">
+        <div class="col-md-6 col-md-12 ml-2">
           <%= render partial: 'shared/search_form' %>
         </div>
       </div>


### PR DESCRIPTION
Fixes #1048 

There were two issues here:

1. The wrong CSS class was used - `col-dm` instead of `col-md`.
2. `col-lg-6` only applies to larger screens, so I changed it to `md`. 

To be perfectly honest, I do not have any Bootstrap experience, so this is kind of a lucky guess. Maybe it's not the "correct" way of doing it.