### PR TITLE
Make profiles tooltip wider

### DIFF
--- a/app/assets/stylesheets/profiles.scss
+++ b/app/assets/stylesheets/profiles.scss
@@ -168,3 +168,7 @@ ul#medialinks__list {
   text-align: left;
   font-size: 12px;
 }
+
+body .tooltip-inner.wide {
+  max-width: 300px;
+}

--- a/app/views/profiles/_profile.html.erb
+++ b/app/views/profiles/_profile.html.erb
@@ -12,5 +12,13 @@
 <% end %>
 
 <script type="text/javascript" charset="utf-8">
-  $(function () { $('[data-toggle="tooltip"]').tooltip() })
+  $(function () {
+    var wideTooltipTemplate = '\
+      <div class="tooltip" role="tooltip">\
+        <div class="arrow" ></div>\
+        <div class="tooltip-inner wide" ></div>\
+      </div>\
+    '
+    $('[data-toggle="tooltip"]').tooltip({ template: wideTooltipTemplate });
+  })
 </script>


### PR DESCRIPTION
* Increases jQuery tooltip max-width to 300
* Affects also tooltip on admin/profiles/[id]/medialinks, which also contain long texts

Fixes #1061
