### PR TITLE
change image upload to only allow jpg, png, gif #1064

### DIFF
--- a/app/assets/stylesheets/pages.scss
+++ b/app/assets/stylesheets/pages.scss
@@ -37,21 +37,22 @@
 .card-header {
   background-color: transparent;
   border: 0;
+  text-align: center;
 }
 
 .card {
   border-radius: 0px;
-  text-align: center;
 }
 
 .card-header:hover {
   border-bottom: 2px solid black;
   text-decoration: none;
+  text-align: center;
   margin-bottom: -2px
 }
 
 .card-header a:hover {
-  text-decoration: none
+  text-decoration: none;
 }
 
 .copyright {

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -175,6 +175,8 @@ class Profile < ApplicationRecord
     if image.attached?
       if image.blob.byte_size > 2.megabyte
         errors.add(:base, :file_size_too_big)
+      elsif image.blob.byte_size < 1.byte
+        errors.add(:base, :file_size_empty)
       elsif !image.content_type.in?(%w(image/png image/jpg image/jpeg image/gif))
         errors.add(:base, :content_type_invalid)
       end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -175,7 +175,7 @@ class Profile < ApplicationRecord
     if image.attached?
       if image.blob.byte_size > 2.megabyte
         errors.add(:base, :file_size_too_big)
-      elsif !image.blob.content_type.starts_with?('image/')
+      elsif !image.content_type.in?(%w(image/png image/jpg image/jpeg image/gif))
         errors.add(:base, :content_type_invalid)
       end
     end

--- a/app/views/pages/faq.en.html.erb
+++ b/app/views/pages/faq.en.html.erb
@@ -192,7 +192,7 @@
           <li>Don't leave too much text in the category "My bio" - it should be clear, easy to understand and meaningful!</li>
           <li>If possible, also fill in the category "Previous Talks". If you have not given any talks so far, describe your experiences in the biography that make up for this! Maybe there is also a website that illustrates your experiences. You can also enter this under "Previous Talks".</li>
           <li>The tags serve to quickly and clearly show where your competences lie, so that the organisers can find a suitable speaker as quickly as possible. Therefore, orient yourself on the existing tags! If you enter new tags, do not use more than 1-2 words and describe your field of competence clearly and self-explanatory!</li>
-        <ul>
+        </ul>
       </div>
     </div>
   </div>

--- a/config/locales/profile.de.yml
+++ b/config/locales/profile.de.yml
@@ -17,7 +17,7 @@ de:
       picture: "Ein Foto von mir:"
       copyright: "Foto-Copyright:"
       image_info: "Lade bitte das Foto in <b>Farbe</b> hoch, wir zeigen es in Graustufen.
-        Nutze .jpg, .jpeg oder .png und achte darauf, daß Du die Rechte zu diesem Foto besitzt!
+        Nutze .jpg, .jpeg, .gif oder .png und achte darauf, daß Du die Rechte zu diesem Foto besitzt!
         Die Größe des Fotos sollte <b>kleiner als 1MB</b> sein."
       willing_to_travel: "Ich bin bereit, für eine Veranstaltung zu reisen"
       nonprofit: "Ich bin bereit, für gemeinnützige Zwecke kostenfrei zu sprechen"

--- a/config/locales/profile.en.yml
+++ b/config/locales/profile.en.yml
@@ -17,7 +17,7 @@ en:
       picture: "A picture of me:"
       copyright: "Picture copyright:"
       image_info: "Please upload a photo in <b>color</b>, we show it in black and white.
-        Make sure you use .jpg, .jpeg or .png and that you have all copyrights for this photo.
+        Make sure you use .jpg, .jpeg, .gif or .png and that you have all copyrights for this photo.
         The size of your photo should be<b> smaller than 1MB</b>."
       firstname: "first name:"
       lastname: "last name:"

--- a/config/locales/rails.de.yml
+++ b/config/locales/rails.de.yml
@@ -103,6 +103,7 @@ de:
       confirmation: stimmt nicht mit der Bestätigung überein
       content_type_invalid: "Das Bild hat ein ungültiges Dateiformat. Es muss ein jpg, jpeg, gif oder png sein."
       file_size_too_big: "Das Bild ist zu groß. Nur Bilder bis zu 2 MB sind erlaubt."
+      file_size_empty: "Ups! Die Datei ist leer. Versuche es erneut."
       empty: muss ausgefüllt werden
       equal_to: muss genau %{count} sein
       even: muss gerade sein

--- a/config/locales/rails.en.yml
+++ b/config/locales/rails.en.yml
@@ -103,6 +103,7 @@ en:
       confirmation: doesn't match confirmation
       content_type_invalid: "The image has an invalid content type. Needs to be a jpg, jpeg, gif or png."
       file_size_too_big: "The image is too big. Only pictures up to 2 MB are allowed."
+      file_size_empty: "Oops! The file is empty. Try again."
       empty: can't be empty
       equal_to: must be equal to %{count}
       even: must be even


### PR DESCRIPTION
change to only allow jpg, png and gif as profile pictures, because otherwise if someone wants to upload webp for example an error occured (picture is uploaded but can not shown)