### PR TITLE
Keep rest of the URL when changing the language

### DIFF
--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -35,7 +35,7 @@
             <%= I18n.locale == :en ? "EN" : "DE" %>
           </a>
           <div class="dropdown-menu" aria-labelledby="navbarDropdownMenuLinkLang" id="DropdownLanguages">
-            <%= I18n.locale == :de ? link_to('EN', {locale: :en}, class: "dropdown-item") : (link_to 'DE', {locale: :de}, class: "dropdown-item") %>
+            <%= I18n.locale == :de ? link_to('EN', params.to_unsafe_h.merge(:locale => :en), class: "dropdown-item") : (link_to 'DE', params.to_unsafe_h.merge(:locale => :de), class: "dropdown-item") %>
           </div>
         </li>
         <% if profile_signed_in? %>

--- a/spec/system/localization_spec.rb
+++ b/spec/system/localization_spec.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
-RSpec.describe 'Localization', type: :system do
-  it 'start page localization' do
+describe 'Changing the language' do
+  let!(:ada) { FactoryBot.create(:ada) }
+
+  it 'stays on start page' do
     visit root_path
 
     within '#DropdownLanguages' do
@@ -17,5 +19,27 @@ RSpec.describe 'Localization', type: :system do
 
     expect(page).to have_link('Log in')
     expect(page).to have_button('Search')
+  end
+
+  it 'stays on profile page' do
+    visit profile_path(id: ada.id)
+    expect(page).to have_content('Contact Ada')
+
+    within '#DropdownLanguages' do
+      click_link 'DE'
+    end
+
+    expect(page).to have_content('Kontaktiere Ada')
+  end
+
+  it 'keeps search results' do
+    visit profiles_path(search: 'Marie')
+    expect(page).to have_content('Marie')
+
+    within '#DropdownLanguages' do
+      click_link 'DE'
+    end
+
+    expect(page).to have_content('Marie')
   end
 end


### PR DESCRIPTION
* Changes locale dropdown to link to current URL with all parameters, only overwriting the locale
  * Uses unsafe_hash of URL to avoid explicit parameter selection
* Adds tests for the behavior

Implements #722