### PR TITLE
Feature 1089 admin profiles index

### DIFF
--- a/app/controllers/admin/profiles_controller.rb
+++ b/app/controllers/admin/profiles_controller.rb
@@ -62,7 +62,11 @@ class Admin::ProfilesController < Admin::BaseController
 
     if @profile.update_attributes(profile_params)
       if params[:page].present?
-        redirect_to redirects[params[:page].to_sym], notice: I18n.t('flash.comment.updated')
+        if /^[0-9]+$/.match("#{params[:page]}")
+          redirect_to "#{admin_profiles_path}?page=#{params[:page]}", notice: I18n.t('flash.profiles.updated', profile_name: @profile.name_or_email)
+        else
+          redirect_to redirects[params[:page].to_sym], notice: I18n.t('flash.comment.updated')
+        end
       else
         redirect_to admin_profiles_path, notice: I18n.t('flash.profiles.updated', profile_name: @profile.name_or_email)
       end

--- a/app/views/admin/profiles/index.html.erb
+++ b/app/views/admin/profiles/index.html.erb
@@ -53,7 +53,7 @@
             <% end %>
           </td>
           <td>
-            <%= form_for profile,{ url: admin_update_admin_profile_path(profile.id), method: 'post' } do |f| %>
+            <%= form_with(model: profile, url: admin_update_admin_profile_path(profile.id), method: 'post') do |f| %>
               <%= f.text_field 'admin_comment' %>
               <%= f.submit t(:add_comment, scope: 'admin.profiles'), class: 'btn btn-primary btn-sm' %>
             <% end  %>

--- a/app/views/admin/profiles/index.html.erb
+++ b/app/views/admin/profiles/index.html.erb
@@ -53,7 +53,7 @@
             <% end %>
           </td>
           <td>
-            <%= form_with(model: profile, url: admin_update_admin_profile_path(profile.id), method: 'post') do |f| %>
+            <%= form_with(model: profile, url: "#{admin_update_admin_profile_path(profile.id)}?#{request.query_string}", method: 'post') do |f| %>
               <%= f.text_field 'admin_comment' %>
               <%= f.submit t(:add_comment, scope: 'admin.profiles'), class: 'btn btn-primary btn-sm' %>
             <% end  %>

--- a/spec/controllers/admin/profiles_controller_spec.rb
+++ b/spec/controllers/admin/profiles_controller_spec.rb
@@ -117,6 +117,32 @@ describe Admin::ProfilesController, type: :controller do
     end
   end
 
+  describe 'PUT admin_update' do
+    before(:each) do
+      sign_in admin
+    end
+
+    it 'redirects to same page in profiles list' do
+      put :admin_update, params: { id: non_admin.id, profile: { admin_comment: "this is a comment" }, page: 2 }
+      expect(response).to redirect_to("/#{I18n.locale}/admin/profiles?page=2")
+    end
+
+    it 'redirects to first page in profiles list' do
+      put :admin_update, params: { id: non_admin.id, profile: { admin_comment: "this is a comment" } }
+      expect(response).to redirect_to("/#{I18n.locale}/admin/profiles")
+    end
+
+    it 'redirects to profile view page' do
+      put :admin_update, params: { id: non_admin.id, profile: { admin_comment: "this is a comment" }, page: 'show' }
+      expect(response).to redirect_to("/#{I18n.locale}/admin/profiles/#{non_admin.slug}")
+    end
+
+    it 'redirects to profile edit page' do
+      put :admin_update, params: { id: non_admin.id, profile: { admin_comment: "this is a comment" }, page: 'edit' }
+      expect(response).to redirect_to("/#{I18n.locale}/admin/profiles/#{non_admin.slug}/edit")
+    end
+  end
+
   describe 'PUT update' do
     context 'when user is admin' do
       before(:each) do


### PR DESCRIPTION
I hope that's the intended behavior of https://github.com/rubymonsters/speakerinnen_liste/issues/1089. Basically, if updating a profile on "en/admin/profiles?page=3", it will redirect back to "en/admin/profiles?page=3" once the profile update is done.