### PR TITLE
Don't show the tooltip triangle when profile tooltip has no data

### DIFF
--- a/app/views/profiles/_profile.html.erb
+++ b/app/views/profiles/_profile.html.erb
@@ -1,6 +1,12 @@
 <% if profile %>
-  <div class="col-sm-6 col-md-4 col-lg-3 my-3 profile-box" data-toggle="tooltip" data-html="true"
-  title="<%= render partial: "profiles/profile_tooltip", locals: { profile: profile } %>">
+  <% tooltip_empty = !profile.iso_languages.present? && profile.city.nil? && profile.willing_to_travel.nil? && profile.nonprofit.nil? %>
+  <% title = render partial: "profiles/profile_tooltip", locals: { profile: profile } %>
+  <div
+    class="col-sm-6 col-md-4 col-lg-3 my-3 profile-box"
+    data-html="true"
+    data-toggle="<%= tooltip_empty ? "" : "tooltip" %>"
+    title="<%= tooltip_empty ? "" : title %>"
+  >
     <%= profile_image_link(profile) %>
     <div>
       <%= link_to profile.fullname, profile %>

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -60,6 +60,21 @@ FactoryBot.define do
       profession { 'chemist' }
     end
 
+    factory :phantom_of_the_opera do
+      firstname { 'Phantom' }
+      lastname { 'of the Opera' }
+      twitter_en { 'phantom_of_the_opera' }
+      city_en { }
+      country { }
+      iso_languages { }
+      bio_de { 'unknown' }
+      bio_en { 'unknown' }
+      main_topic_de { }
+      main_topic_en { }
+      published { true }
+      profession { }
+    end
+
   end
 
   factory :feature do

--- a/spec/system/searching_for_profiles_spec.rb
+++ b/spec/system/searching_for_profiles_spec.rb
@@ -14,6 +14,7 @@ describe 'profile search' do
   let!(:algorithm) { create(:tag_algorithm, locale_languages: [locale_language_en]) }
   let!(:ada) { create(:ada, topic_list: [algorithm]) }
   let!(:marie) { create(:marie, topic_list: [physics]) }
+  let!(:phantom_of_the_opera) { create(:phantom_of_the_opera, topic_list: []) }
   let!(:profile2) { create(:published_profile, firstname: 'Christiane', lastname: 'König', main_topic_en: 'Blogs') }
   let!(:profile3) { create(:published_profile, firstname: 'Maren ', lastname: 'Meier', main_topic_en: 'Big Data') }
   let!(:profile_not_matched) { create(:published_profile, firstname: 'Angela', main_topic_en: 'rassism' ) }
@@ -82,6 +83,18 @@ describe 'profile search' do
 
         expect(page).to have_no_xpath(filter_by_themes_xpath('filter-themes-next-line'))
         expect(page).to have_xpath(filter_by_themes_xpath('float-right'))
+      end
+
+      it 'shows a tooltip when profile has data' do
+        visit profiles_path(search: 'Marie')
+
+        expect(page).to have_selector('[data-toggle="tooltip"]')
+      end
+
+      it 'shows no tooltip when profile has no data' do
+        visit profiles_path(search: 'Phantom')
+
+        expect(page).to have_no_selector('[data-toggle="tooltip"]')
       end
     end
   end


### PR DESCRIPTION
* Fixes Bug: When a profile had no language, city, willing to travel /
  speak for nonprofit flag set, hovering over a profile would only show
  a tooltip triangle
* Adds test for tooltip enable / disable behavior

partially fixes #1087