### PR TITLE
Simplified how seeding is done and updated README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,16 +4,17 @@ dc-run-sp=$(call dc, run --service-ports --rm web $(1))
 
 usage:
 	@echo "Available targets:"
-	@echo "  * setup        		  - Initiates everything (building images, installing gems, creating db and migrating"
-	@echo "  * build        		  - Build image"
-	@echo "  * bundle       		  - Install missing gems"
-	@echo "  * db-migrate   		  - Runs the migrations for dev database"
-	@echo "  * db-test-migrate    - Runs the migrations for test database"
-	@echo "  * dev          		  - Fires a shell inside your container"
-	@echo "  * up           		  - Runs the development server"
-	@echo "  * tear-down    		  - Removes all the containers and tears down the setup"
-	@echo "  * stop         		  - Stops the server"
-	@echo "  * rspec         		  - Runs rspec"
+	@echo "  * setup                  - Initiates everything (building images, installing gems, creating db and migrating"
+	@echo "  * building               - Build image"
+	@echo "  * bundle                 - Install missing gems"
+	@echo "  * db-migrate             - Runs the migrations for dev database"
+	@echo "  * db-test-migrate        - Runs the migrations for test database"
+	@echo "  * seed                   - Seeds dev database with example profiles, and indexes them in Elasticsearch"
+	@echo "  * dev                    - Fires a shell inside your container"
+	@echo "  * up                     - Runs the development server"
+	@echo "  * tear-down              - Removes all the containers and tears down the setup"
+	@echo "  * stop                   - Stops the server"
+	@echo "  * test                   - Runs all tests"
 
 # With db
 setup: build bundle db-create db-migrate db-test-migrate
@@ -38,7 +39,7 @@ db-migrate:
 	$(call dc-run, bundle exec rake db:migrate)
 db-test-migrate:
 	$(call dc-run, bundle exec rake db:migrate RAILS_ENV=test)
-rspec:
-	$(call dc-run-sp, bundle exec rspec)
+seed:
+	$(call dc-run, sh -c 'rake db:seed && rake elasticsearch:import:all')
 test:
 	$(call dc-run-sp, sh -c 'bundle exec rake elasticsearch:wait_for_elastic && bundle exec rspec')

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The aim of the app is to provide a way for conference and event organizers to fi
 First, open a dev shell by running `make dev`.
 
 ```
-# Run all tests of the project
+# Run all tests of the project (same as running `make test`)
 $ bundle exec rspec spec
 
 # If the tests are still failing, run:

--- a/README.md
+++ b/README.md
@@ -10,25 +10,27 @@ The aim of the app is to provide a way for conference and event organizers to fi
 
 1. Clone the repository: `git clone git@github.com:rubymonsters/speakerinnen_liste.git` and access the folder: `cd speakerinnen_liste`. (If you have cloned the repository before and there is still an .env file, delete it.)
 2. If you don't have Docker Engine installed, please download it [here](https://docs.docker.com/install) for your operating system.
-3. Run `make setup` (building images, installing gems, creating db and migrating)
-4. Run `make dev`(opens a shell in which you can run preconfigured commands, e.g. `rake`)
-5. Run `rake db:seed` (Load some initial example profiles) and `rake elasticsearch:import:all` (Import the loaded profiles into the search index)
+3. Run `make setup` (builds images, installs gems, creates and migrates the datasase).
+4. Run `make seed` (seeds database with example profiles and indexes them in Elasticsearch).
 
 ## Development
 
 * `make dev` (opens a development shell, `rake`, `bundle` or `rails` commands will work here)
 * `make up` (starts the app directly)
-* `make test` (runs the tests)
-* `make usage` (get a list of possible commands.)
+* `make test` (runs all the tests)
+* `make usage` (get a list of possible commands)
 
 
 ## Admin user
 
-  If you build or test some admin features you have to create an admin user (by default the admin attribute for each user is set to false) except 1 admin user is initially created by the `db/seed.rb` file.
+  If you build or test admin features, you can use the test admin user to test those. The admin user can be found in [db/seeds.rb](db/seeds.rb#L156-L179). 
 
-  You also can assign the admin status of a user via the rails console:
+  Alternatively, assign the `admin` status to another user via the rails console:
 
   ```ruby
+  # Open a dev shell
+  $ make dev
+
   # Log into the rails console
   $ bundle exec rails c
 
@@ -44,6 +46,8 @@ The aim of the app is to provide a way for conference and event organizers to fi
   ```
 
 # Testing
+
+First, open a dev shell by running `make dev`.
 
 ```
 # Run all tests of the project
@@ -62,7 +66,9 @@ $  bundle exec rspec spec --tag '~elasticsearch'
 # Please use Rubocop
 
 ```
-# Runs rubocop and corrects all errors it can
+# Open a dev shell
+$ make dev
+# Run rubocop and correct all errors it finds
 $ rubocop -a
 ```
 
@@ -73,18 +79,22 @@ Our database schema looks like that:
 ![db](https://user-images.githubusercontent.com/1218914/43900439-368fa600-9be5-11e8-8f9c-d209784de1ef.jpg)
 
 # Metrics
+
 For seeing our metrics we use the free community edition of honeyycomb ( https://ui.honeycomb.io/login )
 More infos how to use this: https://docs.honeycomb.io/beeline/ruby/
 
 # Logging
+
 We are using papertrail.
 `heroku addons:open papertrail --app speakerinnen-liste`
 
 # Report Errors
+
 We are using sentry.
 `heroku addons:open sentry --app speakerinnen-liste`
 
 # Deployment
+
 We use Heroku to deploy.
 
 # Contributing
@@ -95,7 +105,7 @@ If you want to contribute, you can get an overview over the open issues on our [
 
 We are happy to answer your questions if you consider to help. All the issues have a link to their specification. If you want to work on an issue feel free to assign yourself.
 
-Find further details in: https://github.com/rubymonsters/speakerinnen_liste/blob/master/CONTRIBUTING.md
+Find further details in [CONTRIBUTING.md](CONTRIBUTING.md).
 
 # ♥ Code of Conduct
 

--- a/lib/tasks/elasticsearch.rake
+++ b/lib/tasks/elasticsearch.rake
@@ -6,8 +6,10 @@ namespace :elasticsearch do
   namespace :import do
     CLIENT = Elasticsearch::Model.client
 
+    desc 'Index everything in ElasticSearch'
     task all: [:profiles]
 
+    desc 'Index all profiles in ElasticSearch'
     task profiles: :environment do
       profile_task = proc { Indexer.perform(Profile) }
       invoke_task &profile_task


### PR DESCRIPTION
In this PR I:

* Added a `make seed` target so that it's easier to seed *and* index the example profiles when initially building the project.
* Updated README to reflect this new target. I also took the liberty to update some of the other instructions there to make it easier for newcomers. 