### PR TITLE
Mah prevent timeout errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ gem 'aws-sdk-s3', require: false
 gem "sentry-raven"
 
 gem 'image_processing', '~> 1.2'
+gem 'rack-timeout'
 
 group :development do
   gem 'better_errors'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -280,6 +280,7 @@ GEM
       addressable (~> 2.0)
       http (>= 2.0, < 4.0)
     libv8 (6.7.288.46.1)
+    libv8 (6.7.288.46.1-x86_64-linux)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -346,6 +347,7 @@ GEM
     rack-piwik (0.3.0)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
+    rack-timeout (0.6.0)
     rails (5.2.2.1)
       actioncable (= 5.2.2.1)
       actionmailer (= 5.2.2.1)
@@ -482,6 +484,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86_64-linux
 
 DEPENDENCIES
   active_model_serializers
@@ -529,6 +532,7 @@ DEPENDENCIES
   poltergeist (= 1.18.1)
   pry
   rack-piwik (~> 0.3.0)
+  rack-timeout
   rails (= 5.2.2.1)
   rails-controller-testing
   record_tag_helper (~> 1.0)
@@ -546,4 +550,4 @@ RUBY VERSION
    ruby 2.6.5p114
 
 BUNDLED WITH
-   2.1.4
+   2.2.2

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,6 +3,7 @@
 class PagesController < ApplicationController
   def home
     @newest_profiles = Profile
+                .with_attached_image
                 .includes(:translations)
                 .is_published
                 .main_topic_translated_in(I18n.locale)

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -166,6 +166,7 @@ class ProfilesController < ApplicationController
       .pluck(:name)
 
     Profile
+      .with_attached_image
       .is_published
       .includes(:taggings, :translations)
       .joins(:topics)
@@ -176,6 +177,7 @@ class ProfilesController < ApplicationController
 
   def profiles_for_search
     Profile
+      .with_attached_image
       .is_published
       .includes(:taggings, :translations)
       .search(
@@ -191,6 +193,7 @@ class ProfilesController < ApplicationController
 
   def profiles_for_index
     Profile
+      .with_attached_image
       .is_published
       .includes(:translations)
       .main_topic_translated_in(I18n.locale)

--- a/app/models/feature.rb
+++ b/app/models/feature.rb
@@ -6,5 +6,5 @@ class Feature < ApplicationRecord
   translates :title, :description
   globalize_accessors :locales => [:de, :en], :attributes => [:title, :description]
 
-  scope :published_feature, -> { includes({ profiles: :translations }, { profiles: :taggings }, :translations).where(public: true) }
+  scope :published_feature, -> { includes({ profiles: [:translations, :image_attachment] }, :translations).where(public: true) }
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -2,7 +2,6 @@ default: &default
   adapter: postgresql
   encoding: unicode
   pool: 25
-  encoding: unicode
   host: db
   username: postgres
   password: password


### PR DESCRIPTION
The timeout issues seemed to be disappeared after removing the piwik references. But it is recommended to use the gem `rack-timeout` anyways to prevent timeout errors to pile up on the server. So I added it.

Besides I eliminated some n+1 queries to increase performance. 