### PR TITLE
Remove docker in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,28 @@
-language: minimal
+dist: bionic
+language: ruby
+rvm: 2.6.5
+cache:
+  bundler: true
+  directories:
+    - downloads
 
 services:
-  - docker
+  - postgresql
+  - elasticsearch
 
-env:
-  - RAILS_ENV=test RECAPTCHA_SECRET_KEY=6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe RECAPTCHA_SITE_KEY=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI
+addons:
+  postgresql: '9.5'
+
+env: RECAPTCHA_SECRET_KEY=6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe RECAPTCHA_SITE_KEY=6LeIxAcTAAAAAJcZVRqyHh71UMIEGNQ_MXjiZKhI DATABASE_URL=postgres://postgres@127.0.0.1/ SEARCHBOX_URL=http://127.0.0.1:9200/
+
+before_install:
+  # from https://docs.travis-ci.com/user/database-setup/#elasticsearch
+  - mkdir -p downloads
+  - test -e downloads/elasticsearch-6.7.2.deb || curl https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.7.2.deb -o downloads/elasticsearch-6.7.2.deb
+  - sudo dpkg -i --force-confnew downloads/elasticsearch-6.7.2.deb
+  - sudo chown -R elasticsearch:elasticsearch /etc/default/elasticsearch
+  - sudo service elasticsearch restart
 
 before_script:
-  - make setup
-
-script:
-  - make test
+  - psql -c 'create database speakerinnen_test;' -U postgres
+  - sleep 10


### PR DESCRIPTION
This PR changes the travis configuration to *not* use docker. Docker can be helpful in development because it simplifies setting the environment up and getting all the dependencies, but that benefit isn't really so important in travis, since travis has its own mechanisms to do that (addons, etc.), the same way that you don't use it in production because heroku also solves it in its own way. So, since it's creating trouble when exceeding API rate limits, and making the build extra slow, with this PR you can remove it.

There are a couple of things that could be improved in the travis setup but are unrelated, so they can be done separately:

* Are those two secret keys needed to run the tests?
* The `sleep 10` (to give elasticsearch time to get started before start running the tests) could be replaced with something a bit more clever that actually checks it and waits exactly as much as it's needed