### PR TITLE
move database.yml to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # or operating system, you probably want to add a global ignore instead:
 #   git config --global core.excludesfile ~/.gitignore_global
 
+# Ignore database.yml config
+/config/database.yml
+
 # Ignore bundler config
 /.bundle
 

--- a/config/database.yml.sample
+++ b/config/database.yml.sample
@@ -1,0 +1,15 @@
+default: &default
+  adapter: postgresql
+  encoding: unicode
+  pool: 25
+  host: db
+  username: postgres
+  password: password
+
+development:
+  <<: *default
+  database: speakerinnen_development
+
+test:
+  <<: *default
+  database: speakerinnen_test


### PR DESCRIPTION
I tried out to work with docker, but it doesn't work with apples new M1 processor, I guess. So I have installed all without docker and it works with elasticsearch and all tests are green. For this reason I have to change the database.yml file and want to go back to the behavior to make the database file working individually, so I put it in the gitignore file.