### PR TITLE
fix bundle conflict, downgrade elasticsearch to 6.8.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,19 @@
 GIT
   remote: git://github.com/elasticsearch/elasticsearch-ruby.git
-  revision: ca180ae11ac2d851aea98ed8599229df0131801d
+  revision: faaee26ab54a35c6e2b72b8e7d34dcd886b83a58
   ref: 6.x
   specs:
+    elasticsearch (6.8.2)
+      elasticsearch-api (= 6.8.2)
+      elasticsearch-transport (= 6.8.2)
+    elasticsearch-api (6.8.2)
+      multi_json
     elasticsearch-extensions (0.0.31)
       ansi
       elasticsearch
+    elasticsearch-transport (6.8.2)
+      faraday (~> 1)
+      multi_json
 
 GIT
   remote: https://github.com/elastic/elasticsearch-rails.git
@@ -192,14 +200,6 @@ GEM
     diff-lcs (1.4.4)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    elasticsearch (6.8.3)
-      elasticsearch-api (= 6.8.3)
-      elasticsearch-transport (= 6.8.3)
-    elasticsearch-api (6.8.3)
-      multi_json
-    elasticsearch-transport (6.8.3)
-      faraday (~> 1)
-      multi_json
     erubi (1.10.0)
     exception_notification (4.4.3)
       actionmailer (>= 4.0, < 7)
@@ -213,7 +213,7 @@ GEM
       railties (>= 5.0.0)
     faker (1.9.1)
       i18n (>= 0.7)
-    faraday (1.5.0)
+    faraday (1.8.0)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -221,6 +221,7 @@ GEM
       faraday-net_http (~> 1.0)
       faraday-net_http_persistent (~> 1.1)
       faraday-patron (~> 1.0)
+      faraday-rack (~> 1.0)
       multipart-post (>= 1.2, < 3)
       ruby2_keywords (>= 0.0.4)
     faraday-em_http (1.0.0)
@@ -228,8 +229,9 @@ GEM
     faraday-excon (1.1.0)
     faraday-httpclient (1.0.1)
     faraday-net_http (1.0.1)
-    faraday-net_http_persistent (1.1.0)
+    faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
+    faraday-rack (1.0.0)
     ffi (1.15.3)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
@@ -312,6 +314,8 @@ GEM
       addressable (~> 2.0)
       excon
       http (>= 2.0, < 5.0)
+    libv8-node (15.14.0.1-aarch64-linux)
+    libv8-node (15.14.0.1-arm64-darwin-20)
     libv8-node (15.14.0.1-x86_64-linux)
     listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
@@ -331,6 +335,7 @@ GEM
     mini_histogram (0.3.1)
     mini_magick (4.9.5)
     mini_mime (1.1.0)
+    mini_portile2 (2.5.3)
     mini_racer (0.4.0)
       libv8-node (~> 15.14.0.0)
     minitest (5.11.3)
@@ -339,6 +344,11 @@ GEM
     multipart-post (2.1.1)
     nenv (0.3.0)
     nio4r (2.5.7)
+    nokogiri (1.11.7)
+      mini_portile2 (~> 2.5.0)
+      racc (~> 1.4)
+    nokogiri (1.11.7-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.11.7-x86_64-linux)
       racc (~> 1.4)
     normalize-rails (8.0.1)
@@ -462,7 +472,7 @@ GEM
     ruby-statistics (2.1.3)
     ruby-vips (2.1.2)
       ffi (~> 1.12)
-    ruby2_keywords (0.0.4)
+    ruby2_keywords (0.0.5)
     rubyzip (1.3.0)
     sassc (2.4.0)
       ffi (~> 1.9)
@@ -518,6 +528,8 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
+  aarch64-linux
+  arm64-darwin-20
   x86_64-linux
 
 DEPENDENCIES
@@ -585,4 +597,4 @@ RUBY VERSION
    ruby 2.7.2p137
 
 BUNDLED WITH
-   2.2.16
+   2.2.29


### PR DESCRIPTION
I try to make bundle install, but bundler says that elasticsearch 6.8.3 doesn't exist on branch 6.x.
So I made: bundle update elasticsearch elasticsearch-extensions elasticsearch-api elasticsearch-rails
Result is a downgraded bugfix version to 6.8.2
Website works locally and all tests are green. So I think this is ok.