### PR TITLE
Make devise mails working for subdomain

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery
 
   before_action :set_locale
+  before_action :set_request_host
   before_action :set_current_region
   before_action :check_cookie_consent
 
@@ -21,6 +22,15 @@ class ApplicationController < ActionController::Base
     false
   end
   helper_method(:render_footer?)
+
+  def set_request_host
+    Thread.current[:request_host] = request.host
+  end
+
+  def request_host
+    Thread.current[:request_host]
+  end
+  helper_method :request_host
 
   def set_current_region
     @current_region = validate_region($1.to_sym) if request.host =~ %r((.+)\.#{current_domain})

--- a/app/mailers/confirmation_mailer.rb
+++ b/app/mailers/confirmation_mailer.rb
@@ -16,4 +16,13 @@ class ConfirmationMailer < Devise::Mailer
     end
     super
   end
+
+  def request_host
+    Thread.current[:request_host]
+  end
+  helper_method :request_host
+
+  def url_options
+    default_url_options.merge(host: Thread.current[:request_host])
+  end
 end

--- a/app/views/devise/mailer/confirmation_instructions.de.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.de.html.erb
@@ -1,22 +1,19 @@
-<p>Willkommen bei Speakerinnen.org!</p>
+<p>Willkommen bei <%= request_host.capitalize || "Speakerinnen.org" %>!</p>
 
 <p>Wir freuen uns, dass du dich registriert hast. Du kannst den Anmeldeprozess abschließen, wenn du auf den folgenden Link klickst:
-<%= link_to 'Bestätige meinen Account', confirmation_url(@resource, :locale => I18n.locale, :confirmation_token => @token) %></p>
+<%= link_to 'Bestätige meinen Account', confirmation_url(@resource, locale: I18n.locale, confirmation_token: @token) %></p>
 
 <p>Wichtig für dich zu wissen: Alle neuen Profile werden von uns geprüft und erst dann freigeschaltet, wenn sie die notwendigen Anforderungen erfüllen – das geht manchmal ganz schnell, kann aber auch wenige Tage dauern.</p>
 
 <p>Bitte achte darauf, dass neben den allgemeinen Angaben auf jeden Fall die Felder „Meine Biographie“ und „Meine Vorträge“ ausgefüllt sind. Wir können das Profil leider erst freischalten, wenn eines der beiden Felder Informationen enthält. Am besten ist es natürlich, wenn du Angaben in beiden Bereichen machst.</p>
 
-<p>Mehr darüber, was uns bei einem Speakerinnen-Profil wichtig ist, findest du im Guide:<a href="http://speakerinnen.org/de/faq#howto_anker"> How to become a speakerin</a></p>
+<p>Mehr darüber, was uns bei einem Speakerinnen-Profil wichtig ist, findest du im <a href="<%= url_for(controller: :pages, action: :faq, only_path: false) %>">FAQ</a>.</p>
 
 <p>Melde dich gerne bei uns, wenn du Fragen hast! Und natürlich freuen wir uns jederzeit über dein Feedback zu Speakerinnen.org.</p>
 
-
-
 <p>Danke,<br>
 
-Anja, Anne, Christiane, Mandy und Maren<br>
-(das Speakerinnen-Team)
-</p>
+Anja, Christiane, Mandy und Maren<br>
+(das Speakerinnen-Team)</p>
 
-<p>Solltest Du diese E-Mail bekommen, ohne Dich angemeldet zu haben, sag uns bitte Bescheid: <a href="mailto:team@speakerinnen.org">team@speakerinnen.org</a>.</p>
+<p>Solltest du diese E-Mail bekommen, ohne dich angemeldet zu haben, sag uns bitte Bescheid: <a href="mailto:team@speakerinnen.org">team@speakerinnen.org</a>.</p>

--- a/app/views/devise/mailer/confirmation_instructions.en.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.en.html.erb
@@ -1,18 +1,19 @@
-<p>Welcome to Speakerinnen.org!</p>
+<p>Welcome to <%= request_host.capitalize || "Speakerinnen.org" %>!</p>
 
 <p>We are delighted that you have registered with us.</p>
 
-<p>To complete the registration process please click the following link: <%= link_to 'Confirm my account', confirmation_url(@resource, :locale => I18n.locale, :confirmation_token => @token) %></p>
+<p>To complete the registration process please click the following link:
+<%= link_to 'Confirm my account', confirmation_url(@resource, locale: I18n.locale, confirmation_token: @token) %></p>
 
-<p>Every Speakerinnen.org profile will be checked and activated as soon as it is complete. Please ensure that your profile includes information in both the My Bio and Examples of Previous Talks sections. This is crucial for activation of your profile.</p>
+<p>Every profile will be checked and activated as soon as it is complete. Please ensure that your profile includes information in both the My Bio and Examples of Previous Talks sections. This is crucial for activation of your profile.</p>
 
-<p>You’ll find more information about what we value in a profile in our<a href="http://speakerinnen.org/en/faq#howto_anker"> How-to Guide.</a></p>
+<p>You’ll find more information about what we value in a profile in our <a href="<%= url_for(controller: :pages, action: :faq, only_path: false) %>">FAQ</a>.</p>
 
 <p>Please don’t hesitate to contact us if you have any further questions – or if you have any feedback regarding Speakerinnen.org!</p>
 
 <p>Thank you,<br>
 
-Anja, Anne, Christiane, Mandy and Maren<br>
+Anja, Christiane, Mandy and Maren<br>
 (the team of Speakerinnen.org)</p>
 
 <p>If you recieve that e-mail without having signed in, please contact us: <a href="mailto:team@speakerinnen.org">team@speakerinnen.org</a>.</p>

--- a/app/views/devise/mailer/reconfirmation_instructions.de.html.erb
+++ b/app/views/devise/mailer/reconfirmation_instructions.de.html.erb
@@ -1,13 +1,15 @@
-<p>Hallo<%= " #{@resource.firstname}" if @resource.firstname %>!</p>
+<p>Hallo <%= "#{@resource.firstname}" if @resource.firstname %>!</p>
 
-<p>Dein Wunsch zur Änderung deiner E-Mail-Adresse ist bei uns eingetroffen. </p>
+<p>Dein Wunsch zur Änderung deiner E-Mail-Adresse ist bei uns eingetroffen.</p>
+
 <p>Bitte bestätige die Änderung durch einen Klick auf diesen Link:
-<%= link_to 'Bestätigung der Änderung.', confirmation_url(@resource, :locale => I18n.locale, :confirmation_token => @token) %></p>
+<%= link_to 'Bestätigung der Änderung', confirmation_url(@resource, locale: I18n.locale, confirmation_token: @token) %>.</p>
 
 <p>Melde dich gerne bei uns, wenn du Fragen hast! Und natürlich freuen wir uns jederzeit über dein Feedback zu Speakerinnen.org.</p>
 
 <p>Danke,<br>
 
-Anja, Anne, Christiane, Mandy und Maren<br>
-(Das Speakerinnen-Team)
-</p>
+Anja, Christiane, Mandy und Maren<br>
+(Das Speakerinnen-Team)</p>
+
+<p>Falls du keine Änderung deiner E-Mail-Adresse veranlasst hast, kannst du diese E-Mail ignorieren und uns Bescheid sagen: <a href="mailto:team@speakerinnen.org">team@speakerinnen.org</a></p>

--- a/app/views/devise/mailer/reconfirmation_instructions.en.html.erb
+++ b/app/views/devise/mailer/reconfirmation_instructions.en.html.erb
@@ -1,12 +1,15 @@
-<p>Hallo<%= " #{@resource.firstname}" if @resource.firstname %>!</p>
+<p>Hello <%= "#{@resource.firstname}" if @resource.firstname %>!</p>
 
-<p>You have requested to change your email.</p>
+<p>You have requested to change your email address.</p>
 
-<p>To complete the change of the email adress please click the following link: <%= link_to 'Reconfirm my account', confirmation_url(@resource, :locale => I18n.locale, :confirmation_token => @token) %></p>
+<p>To complete the change of the email adress please click the following link:
+<%= link_to 'Reconfirm my account', confirmation_url(@resource, locale: I18n.locale, confirmation_token: @token) %></p>
 
 <p>Please don’t hesitate to contact us if you have any further questions – or if you have any feedback regarding Speakerinnen.org!</p>
 
 <p>Thank you,<br>
 
-Anja, Anne, Christiane, Mandy and Maren<br>
-(the team of Speakerinnen.org)
+Anja, Christiane, Mandy and Maren<br>
+(the team of Speakerinnen.org)</p>
+
+<p>If you have not changed your email address, you can ignore this email, please contact us: <a href="mailto:team@speakerinnen.org">team@speakerinnen.org</a>.</p>

--- a/app/views/devise/mailer/reset_password_instructions.de.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.de.html.erb
@@ -1,8 +1,15 @@
-<p>Hallo <%= @resource.email %>!</p>
+<p>Hallo <%= "#{@resource.firstname}" if @resource.firstname %>!</p>
 
-<p>Jemand hat einen Link angefordert, um dein Passwort zu ändern. Die Änderung kannst Du über diesen Link durchführen:</p>
-
-<p><%= link_to 'Passwort ändern', edit_password_url(@resource, :locale => I18n.locale, :reset_password_token => @token) %></p>
+<p>Du hast dein Passwort vergessen? Kein Problem. Du kannst ein neues Passwort über diesen Link erzeugen:
+<%= link_to 'Passwort ändern', edit_password_url(@resource, locale: I18n.locale, reset_password_token: @token) %></p>
 
 <p>Wenn du diese Anfrage nicht selbst gestellt hast, ignoriere diese E-Mail.</p>
+
 <p>Dein Passwort wird nicht verändert, bis du den Link oben anklickst und ein neues erstellst.</p>
+
+<p>Melde dich gerne bei uns, wenn du Fragen hast! Und natürlich freuen wir uns jederzeit über dein Feedback zu Speakerinnen.org.</p>
+
+<p>Danke,<br>
+
+Anja, Christiane, Mandy und Maren<br>
+(Das Speakerinnen-Team)</p>

--- a/app/views/devise/mailer/reset_password_instructions.en.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.en.html.erb
@@ -1,8 +1,15 @@
-<p>Hello <%= @resource.email %>!</p>
+<p>Hello <%= "#{@resource.firstname}" if @resource.firstname %>!</p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
-
-<p><%= link_to 'Change my password', edit_password_url(@resource, :locale => I18n.locale, :reset_password_token => @token) %></p>
+<p>You have forgotten your password? No problem. You can create a new password through the link below:
+<%= link_to 'Change my password', edit_password_url(@resource, locale: I18n.locale, reset_password_token: @token) %></p>
 
 <p>If you didn't request this, please ignore this email.</p>
+
 <p>Your password won't change until you access the link above and create a new one.</p>
+
+<p>Please don’t hesitate to contact us if you have any further questions – or if you have any feedback regarding Speakerinnen.org!</p>
+
+<p>Thank you,<br>
+
+Anja, Christiane, Mandy and Maren<br>
+(the team of Speakerinnen.org)</p>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -13,7 +13,7 @@ Rails.application.configure do
   config.consider_all_requests_local = true
 
   # mail default url
-  config.action_mailer.default_url_options = { host: 'localhost:3000' }
+  config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.


### PR DESCRIPTION
Using a Thread-local variable to store the current host and use it for sending mails with correct paths so that users from the subdomain are redirected there.
I also adjust the mail texts so that it work for all domains.