### PR TITLE
fix missing host for working with console

### DIFF
--- a/app/mailers/confirmation_mailer.rb
+++ b/app/mailers/confirmation_mailer.rb
@@ -18,11 +18,11 @@ class ConfirmationMailer < Devise::Mailer
   end
 
   def request_host
-    Thread.current[:request_host]
+    Thread.current[:request_host] || default_url_options[:host]
   end
   helper_method :request_host
 
   def url_options
-    default_url_options.merge(host: Thread.current[:request_host])
+    default_url_options.merge(host: request_host)
   end
 end

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -27,6 +27,7 @@
             <% if current_region.nil? %>
               <%= link_to 'Speakerinnen Blog', 'https://blog.speakerinnen.org/', target: '_blank', class: 'dropdown-item' %>
               <%= link_to 'Fiftypercent', 'https://50prozent.speakerinnen.org/', target: '_blank', class: 'dropdown-item'%>
+              <%= link_to 'Speakerinnen Vorarlberg', 'https://vorarlberg.speakerinnen.org/', target: '_blank', class: 'dropdown-item' %>
               <%= link_to t(:about, scope: 'pages.home'), about_path, class: 'dropdown-item' %>
               <%= link_to t(:faq, scope: 'pages.home'), faq_path, class: 'dropdown-item' %>
               <%= link_to t(:code_of_conduct, scope: 'pages.home'), code_of_conduct_path, class: 'dropdown-item' %>


### PR DESCRIPTION
This fixes the problem ( #1214 ) of missing host if someone wants to change something per console. request_host is set in the application controller and not available for the console (host is nil), so for that case the default_url_options (defined in config) are used. 