### PR TITLE
Add new typeahead method

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -101,24 +101,15 @@ class ProfilesController < ApplicationController
   end
 
   def typeahead
-    suggester_options = []
-    suggestions = Profile.typeahead(params[:q])['suggest']
-    suggestions.map { |s| suggester_options.push(s[1][0]['options']) }
-    suggestions_ordered = suggestions_upcase(suggester_options)
-    respond_with(suggestions_ordered)
+    suggestions = Profile.typeahead(params[:q], region: current_region.to_s)
+    suggestions_array = suggestions.map do |suggestion|
+      {'text': suggestion.titleize}
+    end
+    suggestions_array.push('_source': {})
+    respond_with(suggestions_array)
   end
 
   private
-
-  def suggestions_upcase(suggestions_raw)
-    suggestions_raw
-      .flatten
-      .sort_by { |s| s['score'] }
-      .map do |s|
-        s['text'] = s['text'].split.map(&:capitalize).join(' ')
-        s
-      end.uniq { |s| s['text'] }
-  end
 
   # Use callbacks to share common setup or constraints between actions.
   def set_profile

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -237,34 +237,5 @@ module Searchable
         end
       end
     end
-
-    def self.typeahead(q)
-      __elasticsearch__.client.search(
-        index: index_name,
-        body: {
-          suggest: {
-            fullname_suggest: {
-              text: q,
-              completion: { field: 'fullname.suggest' }
-            },
-            lastname_suggest: {
-              text: q,
-              completion: { field: 'lastname.suggest' }
-            },
-            main_topic_de_suggest: {
-              text: q,
-              completion: { field: 'main_topic_de.suggest' }
-            },
-            main_topic_en_suggest: {
-              text: q,
-              completion: { field: 'main_topic_en.suggest' }
-            },
-            topic_list_suggest: {
-              text: q,
-              completion: { field: 'topic_list.suggest' }
-            }
-         }
-      })
-    end
   end
 end

--- a/app/views/shared/_search_form.html.erb
+++ b/app/views/shared/_search_form.html.erb
@@ -1,7 +1,6 @@
 <%= form_tag(profiles_path, method: 'get', class:"form-row home-search") do %>
-  <% classes = current_region ? 'form-control pr-2' : 'form-control pr-2 typeahead' %>
   <label class="sr-only" for="inlineFormInputSearch">Search</label>
-  <%= search_field_tag('search', params[:search], id: "home_search", class:  classes,
+  <%= search_field_tag('search', params[:search], id: "home_search", class:  'form-control pr-2 typeahead',
         type: 'text', placeholder: t(:search_placeholder, scope: 'pages.home') ) %>
   <%= submit_tag((t(:search_speaker, scope: 'pages.home')), class: 'ml-2 btn btn-primary py-0' ) %>
 <% end %>


### PR DESCRIPTION
that does not use elasticsearch anymore with the goal to reimplement scoping of regions. So the subdomain vorarlberg can use typeahead again.