### PR TITLE
remove call to categories table when there are search results

### DIFF
--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -21,7 +21,6 @@ class ProfilesController < ApplicationController
       @aggs_cities = @aggs[:city][:buckets]
       @aggs_states = @aggs[:state][:buckets]
       @aggs_countries = @aggs[:country][:buckets]
-      @three_sample_categories = Category.all.sample(3)
     elsif params[:tag_filter]&.present?
       @tags = params[:tag_filter].split(/\s*,\s*/)
       @profiles = profiles_with_tags

--- a/app/views/shared/_search_filter.erb
+++ b/app/views/shared/_search_filter.erb
@@ -53,7 +53,7 @@
         <br><br>
         <ul class="list-unstyled">
           <%= t(:random_categories, scope: 'search' ).html_safe %><br>
-          <% @three_sample_categories.each do |cat| %>
+          <% Category.all.sample(3).each do |cat| %>
             <li>
               <%= category_link(cat, "speakers_anchor") %>
             </li>


### PR DESCRIPTION
During an investigation of the calls in profiles_controller#index:
in line 24, there is a select in categories table that was called always, but it is used only when there are no search results. 
I removed this line from the controller and moved the call into the view file, so it would be called only in this use case. 
