### PR TITLE
Implement Profile Grouping

### DIFF
--- a/app/services/profile_grouper.rb
+++ b/app/services/profile_grouper.rb
@@ -1,0 +1,78 @@
+class ProfileGrouper
+  CITY_QUERY =
+    <<~HEREDOC
+      WITH normalized_cities_table AS
+        (
+          SELECT
+            profile_id,
+            TRIM(
+              UNNEST(
+                NULLIF(
+                  REGEXP_SPLIT_TO_ARRAY(
+                    city,
+                    ',|/|\\|| und | and | I | & | - '
+                  ),
+                  '{""}'
+                )
+              )
+            ) AS normalized_city
+            FROM profile_translations
+            WHERE locale = $1
+        )
+      SELECT normalized_city, COUNT(profile_id)
+        FROM normalized_cities_table
+        GROUP BY normalized_city
+        HAVING COUNT(profile_id) > 1
+    HEREDOC
+
+  LANGUAGE_QUERY =
+    <<~HEREDOC
+      SELECT
+        ARRAY_TO_STRING(
+          REGEXP_MATCHES(iso_languages, '\- ([a-z]{2})', 'g'),
+          ''
+        ) AS iso_language,
+        COUNT(id)
+        FROM profiles
+        GROUP BY iso_language
+    HEREDOC
+
+  REST_QUERY =
+    <<~HEREDOC
+      SELECT
+        country,
+        state,
+        COUNT(id)
+      FROM profiles
+      GROUP BY GROUPING SETS (country, state)
+    HEREDOC
+
+  attr_reader :locale
+  private :locale
+
+  def initialize(locale)
+    @locale = locale
+  end
+
+  def grouped_cities
+    binds = [ ActiveRecord::Relation::QueryAttribute.new("locale", locale, ActiveRecord::Type::String.new)]
+    @grouped_cities ||= ActiveRecord::Base.connection.exec_query(CITY_QUERY, 'sql', binds).rows
+  end
+
+  def grouped_languages
+    @grouped_languages ||= ActiveRecord::Base.connection.exec_query(LANGUAGE_QUERY).rows
+  end
+
+  def grouped_rest
+    @grouped_rest ||= ActiveRecord::Base.connection.exec_query(REST_QUERY)
+  end
+
+  def agg_hash
+    {
+      languages: grouped_languages.to_h,
+      cities: grouped_cities.to_h,
+      countries: grouped_rest.map { |row| {row["country"] => row["count"]} if row["country"].present? }.compact.inject(:merge!),
+      states: grouped_rest.map { |row| {row["state"] => row["count"]} if row["state"].present? }.compact.inject(:merge!)
+    }
+  end
+end


### PR DESCRIPTION
A second draft of how profile grouping could work. 
- I improved the sanitization for cities so that about 200 cities that were on a group on their own are now grouped with another city. 
- I got the execution time down from 60-70ms to around 45ms. 
- I  managed to get rid off the ruby crutch for the languages by using `REGEXP_MATCHES`.
- I added a way to limit the search for cities by locale

TODO:
- We could probably speed it up more by having only one connection to the database (putting all queries in one `exec_query`-call)
- Incorporating a "base query" so we can group on search results instead of the whole database
- Decide if you want to show cities with count 1 (I added this to reduce noise and make handling the resulting hash in ruby faster, but now that I think about it: After a search you probably want to see the 1's as well, right?)
- Proper documentation and tests(!) so the queries can be maintained easier

Example result:
```ruby
irb(main):001:0> ProfileGrouper.new('en').agg_hash[:countries]
=> {"RU"=>3, "DK"=>2, "SN"=>1, "SG"=>1, "CZ"=>2, "US"=>88, "KE"=>1, "KR"=>1, "JP"=>1, "NZ"=>2, "AU"=>10, "NL"=>19, "CN"=>1, "IN"=>5, "EE"=>1, "AT"=>398, "LI"=>1, "AR"=>1, "CD"=>1, "BR"=>1, "PL"=>2, "MY"=>1, "BW"=>1, "SE"=>7, "CH"=>113, "PK"=>1, "DE"=>2814, "BO"=>1, "LU"=>3, "CA"=>8, "FR"=>11, "CY"=>2, "MX"=>1, "RO"=>2, "FI"=>2, "IE"=>4, "LB"=>1, "AF"=>1, "ZA"=>1, "UA"=>1, "PT"=>4, "ES"=>13, "NG"=>4, "NO"=>3, "IL"=>2, "BA"=>1, "JO"=>1, "IT"=>2, "TN"=>1, "BG"=>1, "GB"=>42, "IS"=>5, "AL"=>2, "GR"=>3, "BE"=>7}
```

```ruby
irb(main):002:0> ProfileGrouper.new('en').agg_hash[:states]
=> {"zurich"=>3, "berlin"=>40, "hesse"=>7, "hamburg"=>6, "bremen"=>3, "bern"=>1, "mecklenburg-vorpommern"=>1, "thuringia"=>4, "schleswig-holstein"=>4, "north-rhine-westphalia"=>22, "vorarlberg"=>84, "bavaria"=>26, "vienna"=>13, "baden-wuerttemberg"=>20, "lower-austria"=>2, "salzburg"=>2, "lower-saxony"=>7, "rhineland-palatinate"=>1, "brandenburg"=>3, "saxony"=>4, "st-gallen"=>1}
```

```ruby
irb(main):003:0> ProfileGrouper.new('en').agg_hash[:languages]
=> {"sk"=>5, "he"=>12, "ja"=>11, "hy"=>1, "sa"=>2, "ar"=>7, "ca"=>5, "ur"=>5, "hu"=>13, "zh"=>20, "lv"=>3, "eo"=>2, "mo"=>2, "uk"=>5, "is"=>9, "sv"=>48, "mt"=>1, "bn"=>1, "ko"=>1, "ku"=>2, "mk"=>2, "en"=>3253, "we"=>2, "fa"=>16, "ka"=>2, "et"=>2, "pl"=>46, "my"=>1, "fi"=>4, "ig"=>1, "be"=>1, "la"=>8, "da"=>19, "fr"=>594, "hi"=>13, "bg"=>9, "ru"=>91, "sg"=>4, "gu"=>1, "hr"=>17, "cs"=>5, "eu"=>1, "th"=>1, "pt"=>55, "sr"=>8, "nn"=>18, "vi"=>4, "bo"=>1, "nl"=>94, "sl"=>1, "it"=>154, "af"=>1, "lt"=>2, "ro"=>11, "lb"=>6, "sq"=>4, "es"=>350, "sw"=>3, "tr"=>27, "de"=>3437, "id"=>4, "el"=>14, "bs"=>4}
```

```ruby
irb(main):004:0> ProfileGrouper.new('en').agg_hash[:cities]
=> {"Marburg"=>3, "Washington"=>3, "Ludwigsburg"=>2, "Montreal"=>2, "Österreich"=>3, "Brussels"=>4, "Bregenz"=>5, "Köln"=>45, "Coburg"=>3, "Copenhagen"=>2, "Oslo"=>2, "Wien"=>109, "Cambridge"=>4, "Main"=>7, "Bern"=>6, "San Francisco"=>18, "Klagenfurt"=>2, "Salzburg"=>12, "Boston"=>3, "Oberursel"=>3, "Bielefeld"=>9, "London"=>25, "Luxemburg"=>2, "Dublin"=>3, "Wiesbaden"=>10, "Oldenburg"=>5, "Konstanz"=>3, "NYC"=>2, "Bristol"=>2, "Washington DC"=>3, "Luzern"=>3, "berlin"=>3, "Zürich"=>34, "Chicago"=>4, "Finland"=>2, "Portland"=>4, "Seattle"=>8, "Ahlen"=>2, "Halle"=>3, "Gütersloh"=>2, "Offenbach"=>2, "Melbourne"=>2, "München"=>94, "OR"=>2, "Braunschweig"=>5, "Nürnberg"=>4, "Freiburg im Breisgau"=>2, "Erfurt"=>6, "Dusseldorf"=>3, "Bonn"=>20, "Dornbirn"=>4, "Utrecht"=>2, "Gothenburg"=>2, "Engelskirchen"=>2, "Jena"=>8, "Lagos"=>3, "Feldkirch"=>5, "Dresden"=>16, "India"=>2, "Innsbruck"=>5, "wien"=>2, "Greifswald"=>2, "Schweiz"=>3, "Eisenstadt"=>2, "CA"=>2, "Heidelberg"=>10, "Switzerland"=>2, "Hamburg"=>180, "Geneva"=>2, "Aschaffenburg"=>2, "Munich"=>59, "Nijmegen (NL)"=>2, "Erding"=>2, "Denver"=>2, "Plauen"=>2, "Madrid"=>3, "Osnabrück"=>7, "Toronto"=>2, "Leeds"=>2, "Essen"=>12, "Stuttgart"=>28, "Köln-Bonn"=>2, "Kassel"=>8, "Leipzig"=>40, "Rosenheim"=>4, "Trier"=>2, "Friedrichshafen"=>3, "DC"=>3, "Ulm"=>3, "Stockholm"=>2, "Karlsruhe"=>25, "Vancouver"=>3, "Göttingen"=>3, "Berkeley"=>2, "Frankfurt"=>45, "New York"=>7, "Berlin"=>698, "Germany"=>30, "Canada"=>2, "Mainz"=>6, "Barcelona"=>7, "Nuremberg"=>2, "Bremen"=>23, "Lübeck"=>2, "Belfast"=>2, "Cologne"=>26, "Magdeburg"=>2, "Athens"=>3, "Glasgow"=>2, "Tübingen"=>3, "Graz"=>14, "Amsterdam"=>8, "Heilbronn"=>3, "Brüssel"=>2, "Ingolstadt"=>3, "Lörrach"=>2, "Winterthur"=>2, "Aachen"=>15, "Sydney"=>3, "Münster"=>7, "Vienna"=>66, "Duisburg"=>2, "Linz"=>14, "Bochum"=>9, "Potsdam"=>8, "Augsburg"=>7, "Montpellier"=>2, "Hanover"=>4, "Leverkusen"=>3, "Kiel"=>4, "Brooklyn"=>2, "Mannheim"=>17, "Dortmund"=>17, ""=>3, "UK"=>3, "Basel"=>6, "Los Angeles"=>4, "WA"=>2, "MA"=>2, "California"=>2, "Düsseldorf"=>34, "Wuppertal"=>5, "Darmstadt"=>9, "Paris"=>5, "Frankfurt am Main"=>26, "USA"=>2, "Bayern"=>2, "Ratingen"=>2, "Saarbrücken"=>6, "Malmö"=>4, "Bangalore"=>2, "Hannover"=>22, "Austria"=>4, "Zurich"=>13, "Landshut"=>2, "Würzburg"=>8, "Freiburg"=>10}
```