### PR TITLE
Fix category view of profiles

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -3,18 +3,7 @@
 class PagesController < ApplicationController
   def home
     # we take the seven newest profiles and keep one as an empty example
-    @newest_profiles = []
-    last_seven_profiles.each do |profile|
-      @newest_profiles << {
-                      id: profile.id,
-                      fullname: profile.fullname,
-                      iso_languages: profile.iso_languages,
-                      city: profile.city,
-                      willing_to_travel: profile.willing_to_travel,
-                      nonprofit: profile.nonprofit,
-                      main_topic_or_first_topic: profile.main_topic_or_first_topic
-                    }
-    end
+    @newest_profiles = last_seven_profiles
 
     select_special_medicine_profiles
 
@@ -41,7 +30,7 @@ class PagesController < ApplicationController
       {
         title: feature.title,
         description: feature.description,
-        profiles: feature.profiles.map(&:profile_card_details)
+        profiles: feature.profiles
       }
     end
   end

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -116,16 +116,28 @@ class Profile < ApplicationRecord
     suggestions.map { |s| s.downcase }.uniq
   end
 
+  Struct.new(
+    'ProfileCardDetails',
+    :id,
+    :fullname,
+    :iso_languages,
+    :city,
+    :willing_to_travel,
+    :nonprofit,
+    :main_topic_or_first_topic,
+    keyword_init: true
+  )
+
   def profile_card_details
-    {
+    Struct::ProfileCardDetails.new(
       id: id,
       fullname: fullname,
       iso_languages: iso_languages,
       city: city,
       willing_to_travel: willing_to_travel,
       nonprofit: nonprofit,
-      main_topic_or_first_topic: main_topic_or_first_topic
-    }
+      main_topic_or_first_topic: main_topic_or_first_topic,
+    )
   end
 
   def fullname

--- a/app/views/profiles/_profile.html.erb
+++ b/app/views/profiles/_profile.html.erb
@@ -1,15 +1,15 @@
 <% if profile %>
-  <% tooltip_empty = !profile[:iso_languages].present? && profile[:city].nil? && profile[:willing_to_travel].nil? && profile[:nonprofit].nil? %>
+  <% tooltip_empty = !profile.iso_languages.present? && profile.city.nil? && profile.willing_to_travel.nil? && profile.nonprofit.nil? %>
   <% title = render partial: "profiles/profile_tooltip", locals: { profile: profile } %>
   <div class="col-sm-6 col-md-6 col-lg-3 my-3 profile-box">
-    <%= profile_image_link(Profile.find(profile[:id])) %>
+    <%= profile_image_link(Profile.find(profile.id)) %>
     <div class="bg--white caption">
       <div class="profile-name">
-        <%= link_to profile[:fullname], profile_path(profile[:id]) %>
+        <%= link_to profile.fullname, profile_path(profile.id) %>
       </div>
       <div class="profile-subtitle">
         <p>
-          <%= profile[:main_topic_or_first_topic].truncate(60) if profile[:main_topic_or_first_topic] %>
+          <%= profile.main_topic_or_first_topic.truncate(60) if profile.main_topic_or_first_topic %>
         </p>
         <div
           class="profile-tooltip"

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -5,7 +5,7 @@
     <div class="row">
       <div class="col-12 py-5">
         <span class="h4">
-          <%= t(:"result#{'_' + current_region.to_s if current_region}", scope: 'search', count: @profiles_count).html_safe %><b><%= params[:search] %></b>
+          <%= t(:"result#{'_' + current_region.to_s if current_region}", scope: 'search', count: @pagy.count).html_safe %><b><%= params[:search] %></b>
         </span>
       </div>
     </div>
@@ -39,7 +39,7 @@
         <a id="speakers_anchor"></a>
         <% if params[:category_id] %>
           <h1><%= @category.name %></h1>
-          <h3><%= t(:"profiles_in_category#{'_' + current_region.to_s if current_region}", scope: 'profiles.index', count: @profiles_count).html_safe %> </h3>
+          <h3><%= t(:"profiles_in_category#{'_' + current_region.to_s if current_region}", scope: 'profiles.index', count: @pagy.count).html_safe %> </h3>
           <% if current_region %>
             <p>
               <%= t(:expand_search, scope: 'search') %>
@@ -48,7 +48,7 @@
           <% end %>
         <% elsif params[:tag_filter] %>
           <h1>
-            <%= t(:all_tagged_speakerinnen, scope: 'profiles.index', count: @profiles_count).html_safe + t(:tag_filter, scope: 'profiles.index', count: @tags.count).html_safe %>
+            <%= t(:all_tagged_speakerinnen, scope: 'profiles.index', count: @pagy.count).html_safe + t(:tag_filter, scope: 'profiles.index', count: @tags.count).html_safe %>
           </h1>
         <% else %>
           <h1><%= t(:all_profiles, scope: 'profiles.index') %></h1>

--- a/app/views/shared/_search_filter.erb
+++ b/app/views/shared/_search_filter.erb
@@ -1,4 +1,4 @@
-<% if @profiles_count > 0 %>
+<% if @pagy.count > 0 %>
   <div class="row row-cols-4">
     <div class="col-12 col-sm-6 col-md-3">
       <ul id="facet_languages" class="search-aggregation list-unstyled">

--- a/spec/controllers/profiles_controller_spec.rb
+++ b/spec/controllers/profiles_controller_spec.rb
@@ -20,7 +20,7 @@ describe ProfilesController, type: :controller do
     end
 
     it 'displays published profiles' do
-      expect(assigns(:profiles).map { |hash| hash[:id] }).to eq ([ada.id])
+      expect(assigns(:records).pluck(:id)).to eq ([ada.id])
     end
 
     it 'does not include unpublished profiles' do


### PR DESCRIPTION
that was broken due to a huge amount of profiles that had to pass through the profile_card_details method.
We don't need to do that here because we can pass pagy different kinds of collections. We only need the pagy_arrays for the search results. All other types of results can be passed as an ActiveRecordRelation.

We also refactored the profile_card_details to be a Struct. This allows us to use the same partial to display the profile cards with the different kinds of collections.