### PR TITLE
Remove unused route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,8 +60,6 @@ Rails.application.routes.draw do
         registrations: :registrations
       }
 
-    get 'topics', to: 'profiles#index', as: :topic
-
     get 'profiles_typeahead' => 'profiles#typeahead'
 
     get  'contact' => 'contact#new',    as: 'contact'


### PR DESCRIPTION
Right now the bots are scraping our website with the topic param.  
We have no special routing for that but show all speakerinnen with their images. This might cause  a lot of request we do not want to have.

Since we don't use linked topics  at the moment, we can get rid of the route