### PR TITLE
Block access to deprecated path

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -75,4 +75,9 @@ class Rack::Attack
   #    {},   # headers
   #    ['']] # body
   # end
+
+  blocklist('block all access to deprecated paths') do |request|
+    # Requests are blocked if the return value is truthy
+    request.path.start_with?("/topics")
+  end
 end


### PR DESCRIPTION
since some bots do not respect the robots.txt and pollute the logs.

https://github.com/rack/rack-attack?tab=readme-ov-file#blocklistname-block