### PR TITLE
Reinsert topics route which crawlers still use

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,7 +49,7 @@ Rails.application.routes.draw do
       end
     end
 
-
+    get 'topics', to: 'profiles#index', as: :topic
 
     get 'profiles_typeahead' => 'profiles#typeahead'
 


### PR DESCRIPTION
since this creates loads of errors we'll try to block those requests via rack attack. This currently does not work because the error occurs before rack attack starts working.

[#1361]