### PR TITLE
Quickfix: lookup for first topic is expensive

### DIFF
--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -151,7 +151,9 @@ class Profile < ApplicationRecord
   end
 
   def main_topic_or_first_topic
-    main_topic.present? ? main_topic : taggings.map { |tagging| tagging&.tag&.name }&.first
+    return nil unless main_topic
+
+    main_topic
   end
 
   # Try building a slug based on the following fields in


### PR DESCRIPTION
since there are only 142 profiles that don't have one we will leave it empty for now and don't show anything. In the next steps we will migrate the data so every profile has a main topic again.