### PR TITLE
Another step to get rid of more bot crawls

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -62,7 +62,7 @@ class ApplicationController < ActionController::Base
     return if Rails.env.test?
     return unless request.is_crawler?
 
-    logger.warn "Crawler was here: #{request.crawler_name}"
+    logger.warn "Crawler was here: #{request.crawler_name} #{request.user_agent}"
   end
 
   def build_missing_translations(object)

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -30,7 +30,7 @@ class Rack::Attack
     req.user_agent if req.user_agent.present? && req.user_agent.match(/\Acrawl\z/i)
   end
 
-  throttle('req/ip', limit: 100, period: 5.minutes) do |req|
+  throttle('req/ip', limit: 20, period: 1.minutes) do |req|
     req.ip
   end
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -63,3 +63,6 @@ Disallow: /
 
 User-Agent: Bingbot
 Crawl-delay: 20
+
+User-Agent: SEOkicks
+Disallow: /

--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -14,15 +14,15 @@ RSpec.describe "Rack::Attack", type: :request do
   end
 
   describe "get /profiles" do
-    it "successful for 10 requests, then blocks the user nicely" do
-      100.times do
+    it "successful for 20 requests, then blocks the user nicely" do
+      20.times do
         get profiles_path
         expect(response).to have_http_status(:ok)
       end
       get profiles_path
       expect(response.body).to include("Retry later")
       expect(response).to have_http_status(:too_many_requests)
-      travel_to(5.minutes.from_now) do
+      travel_to(1.minutes.from_now) do
         get profiles_path
         expect(response).to have_http_status(:ok)
       end


### PR DESCRIPTION
- log user agent to identify special bot
- change unit of throttle limit for the same ip
- disallow another bot via robots.txt