### PR TITLE
fix for  iso_2 and iso_3 languages in the search aggregator

### DIFF
--- a/config/locales/languages.de.yml
+++ b/config/locales/languages.de.yml
@@ -91,6 +91,9 @@ de:
     vo: "volapük"
     yi: "jiddisch"
     zh: "chinesisch"
-    wen: "sorbisch"                 #   iso_639_2:
-    sgn: "gebärdensprachen"         #   iso_639_2:
-    nds: "plattdeutsch"              #   iso_639_3:
+    wen: "sorbisch"                # iso_639_2:
+    we: "sorbisch"                 # no real iso_639_1 code but needed for the language search https://github.com/rubymonsters/speakerinnen_liste/blob/ee24b53537e777e796f5ce6173b77377023f9dc8/app/services/profile_grouper.rb#L32
+    sgn: "gebärdensprachen"        # iso_639_2:
+    sg: "gebärdensprachen"         # no real iso_639_1 code but needed for the language search
+    nds: "plattdeutsch"            # iso_639_3:
+    nd: "plattdeutsch"             # no real iso_639_1 code but needed for the language search

--- a/config/locales/languages.en.yml
+++ b/config/locales/languages.en.yml
@@ -91,6 +91,9 @@ en:
     vo: "volapuk"
     yi: "yiddish"
     zh: "chinese"
-    wen: "sorbian"                #   iso_639_2:
-    sgn: "sign languages"         #   iso_639_2:
-    nds: "low german"              #   iso_639_3:
+    wen: "sorbian"                 # iso_639_2:
+    we: "sorbisch"                 # no real iso_639_1 code but needed for the language search https://github.com/rubymonsters/speakerinnen_liste/blob/ee24b53537e777e796f5ce6173b77377023f9dc8/app/services/profile_grouper.rb#L32
+    sgn: "sign languages"          # iso_639_2:
+    sg: "sign languages"           # no real iso_639_1 code but needed for the language search
+    nds: "low german"              # iso_639_3:
+    nd: "low german"               # no real iso_639_1 code but needed for the language search


### PR DESCRIPTION
In the search aggregator: https://github.com/rubymonsters/speakerinnen_liste/blob/ee24b53537e777e796f5ce6173b77377023f9dc8/app/services/profile_grouper.rb#L32

we grab the first 2 letters and that yields to no results in the language yml where we have for 3 languages 3 letters. 

<img width="971" alt="image" src="https://github.com/user-attachments/assets/d21f911d-7871-4e38-a52b-2ef3ad663373" />


