### PR TITLE
Fix positioning of tagit close icon

### DIFF
--- a/app/assets/stylesheets/profiles.scss
+++ b/app/assets/stylesheets/profiles.scss
@@ -348,3 +348,11 @@ ul#medialinks__list {
 body .tooltip-inner.wide {
   max-width: 300px;
 }
+
+/* tags */
+.tagit-label {
+  margin-right: 10px;
+}
+.ui-icon {
+  margin-top: -10px;
+}


### PR DESCRIPTION
Closes #1451

Before:

<img width="755" height="405" alt="Bildschirmfoto 2025-10-05 um 15 47 51" src="https://github.com/user-attachments/assets/a2bb036d-23f3-41ac-b2e8-4a0f0ccc9c9e" />

After

<img width="778" height="466" alt="Bildschirmfoto 2025-10-05 um 15 46 18" src="https://github.com/user-attachments/assets/4018a4b4-67fe-4c7b-a68f-08e47a33eb65" />


