### PR TITLE
remove the cache because this caches the first tagbox you see and doe…

### DIFF
--- a/app/views/shared/_category_filter.erb
+++ b/app/views/shared/_category_filter.erb
@@ -19,11 +19,9 @@
     <% end %>
     <div class="tab-content mb-3" id="available-tags-box">
       <% @categories.each do |category| %>
-        <% cache category, expires_in: 1.hour do %>
-          <div style="min-height: 300px" class="tab-pane fade <%= "active show" if category.id.to_s == ( params[:category_id]  || @category.id.to_s )%>" id="v-pills-<%= category.slug %>" role="tabpanel" aria-labelledby="v-pills-<%= category.slug %>-tab" >
-            <%= render partial: "shared/tagbox", locals: { :tags => instance_variable_get("@tags_#{category.slug}"), :category => category } %>
-          </div>
-        <% end %>
+        <div style="min-height: 300px" class="tab-pane fade <%= "active show" if category.id.to_s == ( params[:category_id]  || @category.id.to_s )%>" id="v-pills-<%= category.slug %>" role="tabpanel" aria-labelledby="v-pills-<%= category.slug %>-tab" >
+          <%= render partial: "shared/tagbox", locals: { :tags => instance_variable_get("@tags_#{category.slug}"), :category => category } %>
+        </div>
       <% end %>
     </div>
     <div id="selected-tags-box" class="my-3">


### PR DESCRIPTION
remove the cache because this caches the tagbox you see and does not show the one you selected on the startpage


When you click on a category on the start page ->
<img width="1134" height="738" alt="image" src="https://github.com/user-attachments/assets/ec9145e1-5f72-4d10-929a-677c2b2ff0ff" />

you want to see the tags in the tagbox that belong to it ->
<img width="1225" height="787" alt="image" src="https://github.com/user-attachments/assets/79673337-a680-4be3-b81f-849e5b786e31" />


Now you see always the same. The tags of the category that was cached every hour.