### PR TITLE
Update erb gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,9 @@ source 'https://rubygems.org'
 ruby '3.4.9'
 gem 'rails', '~> 8.0.0'
 
+# patch for CVE‑2026‑41316, can be removed with ruby 4.0.3
+gem 'erb', '~> 6.0.4'
+
 # Needed for Javascript Runtime
 # gem 'therubyracer'
 gem 'mini_racer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,6 +183,7 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.5.1)
     drb (2.2.3)
+    erb (6.0.4)
     erubi (1.13.1)
     exception_notification (5.0.1)
       actionmailer (>= 7.1, < 9)
@@ -530,6 +531,7 @@ DEPENDENCIES
   database_cleaner (~> 2.0, >= 2.0.2)
   derailed_benchmarks
   devise (~> 4.7)
+  erb (~> 6.0.4)
   exception_notification
   factory_bot_rails
   faker (~> 3.1, >= 3.1.1)


### PR DESCRIPTION
fix version that addresses CVE‑2026‑41316. Normally erb is a default gem. We can go back to normal as soon as we update to ruby 4.0.3