### PR TITLE
Fix flaky Rack::Attack throttle spec

### DIFF
--- a/spec/requests/rack_attack_spec.rb
+++ b/spec/requests/rack_attack_spec.rb
@@ -14,15 +14,21 @@ RSpec.describe "Rack::Attack", type: :request do
   end
 
   describe "get /profiles" do
-    it "successful for 20 requests, then blocks the user nicely" do
-      100.times do
+    it "successful for 100 requests, then blocks the user nicely" do
+      # Freeze time so all requests fall inside a single throttle period.
+      # Rack::Attack counts into fixed wall-clock buckets, so without this
+      # the batch can straddle a period boundary (likelier on slow CI),
+      # reset the counter mid-run, and never reach the limit.
+      freeze_time do
+        100.times do
+          get profiles_path
+          expect(response).to have_http_status(:ok)
+        end
         get profiles_path
-        expect(response).to have_http_status(:ok)
+        expect(response.body).to include("Retry later")
+        expect(response).to have_http_status(:too_many_requests)
       end
-      get profiles_path
-      expect(response.body).to include("Retry later")
-      expect(response).to have_http_status(:too_many_requests)
-      travel_to(1.minutes.from_now) do
+      travel_to(1.minute.from_now) do
         get profiles_path
         expect(response).to have_http_status(:ok)
       end


### PR DESCRIPTION
## Problem

`spec/requests/rack_attack_spec.rb` intermittently fails in CI (e.g. it surfaced on the unrelated net-imap bump PR #1601). The failure:

```
Rack::Attack get /profiles successful for 20 requests, then blocks the user nicely
  expected the response body to include "Retry later" (got a normal 200 page)
```

## Cause

The spec fires 101 requests and expects the 101st to be throttled (`req/ip` limit is `100/1.minute`). The request batch was **not** time-frozen. Rack::Attack counts requests into **fixed wall-clock buckets** (`Time.now.to_i / period`), not a sliding window from the first request. When the batch straddles a 1-minute boundary — much likelier on slow CI — the counter resets mid-run, the limit is never reached in a single bucket, and the request that should be blocked returns `200` instead of `429`. Locally it runs in ~3s so all requests land in one bucket and it passes.

## Fix

Wrap the request batch in `freeze_time` so all 101 requests share a single throttle period. The subsequent `travel_to(1.minute.from_now)` reset check is preserved. Also corrected the misleading "20 requests" description (the limit is 100).

Verified: ran the spec 3× locally, passes deterministically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)